### PR TITLE
Add module graph analyser

### DIFF
--- a/src/Analyser.elm
+++ b/src/Analyser.elm
@@ -12,7 +12,7 @@ import Tuple2
 import Analyser.Messages.Util as Messages
 import Analyser.ContextLoader as ContextLoader exposing (Context)
 import Analyser.Configuration as Configuration exposing (Configuration)
-import Graph as Graph
+import Graph
 import Logger
 
 

--- a/src/Analyser.elm
+++ b/src/Analyser.elm
@@ -12,6 +12,7 @@ import Tuple2
 import Analyser.Messages.Util as Messages
 import Analyser.ContextLoader as ContextLoader exposing (Context)
 import Analyser.Configuration as Configuration exposing (Configuration)
+import Graph as Graph
 import Logger
 
 
@@ -224,8 +225,12 @@ onSourceLoadingStageMsg x stage model =
                 messages =
                     Inspection.run (SourceLoadingStage.parsedFiles newStage) model.dependencies model.configuration
 
+                newGraph =
+                    Graph.run (SourceLoadingStage.parsedFiles newStage) model.dependencies
+
                 newState =
                     State.finishWithNewMessages messages model.state
+                        |> State.updateGraph newGraph
 
                 newModel =
                     { model

--- a/src/Analyser/State.elm
+++ b/src/Analyser/State.elm
@@ -3,7 +3,7 @@ module Analyser.State exposing (..)
 import Analyser.Messages.Types exposing (Message, MessageId, MessageStatus(Applicable))
 import Analyser.Messages.Json exposing (encodeMessage, decodeMessage)
 import Analyser.Messages.Util as Messages exposing (blockForShas, markFixing)
-import Graph as Graph exposing (Graph)
+import Graph exposing (Graph)
 import Json.Encode as JE exposing (Value)
 import Json.Decode as JD exposing (Decoder)
 import Json.Decode.Extra exposing ((|:))
@@ -34,7 +34,7 @@ initialState =
     , idCount = 0
     , status = Initialising
     , queue = []
-    , graph = Graph.init []
+    , graph = Graph.empty
     }
 
 

--- a/src/Analyser/State.elm
+++ b/src/Analyser/State.elm
@@ -3,6 +3,7 @@ module Analyser.State exposing (..)
 import Analyser.Messages.Types exposing (Message, MessageId, MessageStatus(Applicable))
 import Analyser.Messages.Json exposing (encodeMessage, decodeMessage)
 import Analyser.Messages.Util as Messages exposing (blockForShas, markFixing)
+import Graph as Graph exposing (Graph)
 import Json.Encode as JE exposing (Value)
 import Json.Decode as JD exposing (Decoder)
 import Json.Decode.Extra exposing ((|:))
@@ -13,6 +14,7 @@ type alias State =
     , idCount : Int
     , status : Status
     , queue : List Task
+    , graph : Graph
     }
 
 
@@ -32,6 +34,7 @@ initialState =
     , idCount = 0
     , status = Initialising
     , queue = []
+    , graph = Graph.init []
     }
 
 
@@ -103,6 +106,11 @@ finishWithNewMessages messages s =
             |> sortMessages
 
 
+updateGraph : Graph -> State -> State
+updateGraph newGraph s =
+    { s | graph = newGraph }
+
+
 decodeState : Decoder State
 decodeState =
     JD.succeed State
@@ -110,6 +118,7 @@ decodeState =
         |: JD.field "idCount" JD.int
         |: JD.field "status" decodeStatus
         |: JD.field "queue" (JD.list JD.int)
+        |: JD.field "graph" Graph.decode
 
 
 encodeState : State -> Value
@@ -119,6 +128,7 @@ encodeState state =
         , ( "idCount", JE.int state.idCount )
         , ( "status", encodeStatus state.status )
         , ( "queue", JE.list (List.map JE.int state.queue) )
+        , ( "graph", Graph.encode state.graph )
         ]
 
 

--- a/src/Client/App/App.elm
+++ b/src/Client/App/App.elm
@@ -1,9 +1,9 @@
 module Client.App.App exposing (init, view, update, subscriptions)
 
 import Client.App.Menu
-import Client.App.Models exposing (Content(DashBoardContent, DependencyGraphContent, FileTreeContent), Model, Msg(..))
+import Client.App.Models exposing (Content(DashBoardContent, GraphContent, FileTreeContent), Model, Msg(..))
 import Client.DashBoard.DashBoard as DashBoard
-import Client.DependencyGraph.DependencyGraph as DependencyGraph
+import Client.Graph.Graph as Graph
 import Client.FileTree as FileTree
 import Client.Socket exposing (controlAddress)
 import Html exposing (Html, div)
@@ -20,8 +20,8 @@ subscriptions model =
             DashBoardContent sub ->
                 DashBoard.subscriptions model.location sub |> Sub.map DashBoardMsg
 
-            DependencyGraphContent sub ->
-                DependencyGraph.subscriptions model.location sub |> Sub.map DependencyGraphMsg
+            GraphContent sub ->
+                Graph.subscriptions model.location sub |> Sub.map GraphMsg
 
             FileTreeContent sub ->
                 FileTree.subscriptions model.location sub |> Sub.map FileTreeMsg
@@ -43,9 +43,9 @@ onLocation l =
                 |> Tuple2.mapSecond (Cmd.map FileTreeMsg)
 
         "#dependency-graph" ->
-            DependencyGraph.init l
-                |> Tuple2.mapFirst (\x -> { content = DependencyGraphContent x, location = l })
-                |> Tuple2.mapSecond (Cmd.map DependencyGraphMsg)
+            Graph.init l
+                |> Tuple2.mapFirst (\x -> { content = GraphContent x, location = l })
+                |> Tuple2.mapSecond (Cmd.map GraphMsg)
 
         _ ->
             DashBoard.init l
@@ -62,8 +62,8 @@ view m =
                 DashBoardContent subModel ->
                     DashBoard.view subModel |> Html.map DashBoardMsg
 
-                DependencyGraphContent subModel ->
-                    DependencyGraph.view subModel |> Html.map DependencyGraphMsg
+                GraphContent subModel ->
+                    Graph.view subModel |> Html.map GraphMsg
 
                 FileTreeContent subModel ->
                     FileTree.view subModel |> Html.map FileTreeMsg
@@ -85,8 +85,8 @@ update msg model =
         DashBoardMsg subMsg ->
             onDashBoardMsg subMsg model
 
-        DependencyGraphMsg subMsg ->
-            onDependencyGraphMsg subMsg model
+        GraphMsg subMsg ->
+            onGraphMsg subMsg model
 
         FileTreeMsg subMsg ->
             onFileTreeMsg subMsg model
@@ -116,13 +116,13 @@ onDashBoardMsg subMsg model =
             model ! []
 
 
-onDependencyGraphMsg : DependencyGraph.Msg -> Model -> ( Model, Cmd Msg )
-onDependencyGraphMsg subMsg model =
+onGraphMsg : Graph.Msg -> Model -> ( Model, Cmd Msg )
+onGraphMsg subMsg model =
     case model.content of
-        DependencyGraphContent subModel ->
-            DependencyGraph.update model.location subMsg subModel
-                |> Tuple2.mapFirst (\x -> { model | content = DependencyGraphContent x })
-                |> Tuple2.mapSecond (Cmd.map DependencyGraphMsg)
+        GraphContent subModel ->
+            Graph.update model.location subMsg subModel
+                |> Tuple2.mapFirst (\x -> { model | content = GraphContent x })
+                |> Tuple2.mapSecond (Cmd.map GraphMsg)
 
         _ ->
             model ! []

--- a/src/Client/App/Menu.elm
+++ b/src/Client/App/Menu.elm
@@ -26,7 +26,8 @@ view l =
                 [ ul [ class "nav in" ]
                     [ menuItem l "#dashboard" "Dashboard" "dashboard"
                     , menuItem l "#tree" "Tree" "files-o"
-                    , menuItem l "#dependency-graph" "Dependency graph" "cubes"
+                      -- Pending https://github.com/stil4m/elm-analyse/issues/40:
+                      -- , menuItem l "#dependency-graph" "Dependency graph" "cubes"
                     ]
                 ]
             ]

--- a/src/Client/App/Menu.elm
+++ b/src/Client/App/Menu.elm
@@ -26,6 +26,7 @@ view l =
                 [ ul [ class "nav in" ]
                     [ menuItem l "#dashboard" "Dashboard" "dashboard"
                     , menuItem l "#tree" "Tree" "files-o"
+                    , menuItem l "#dependency-graph" "Dependency graph" "cubes"
                     ]
                 ]
             ]

--- a/src/Client/App/Models.elm
+++ b/src/Client/App/Models.elm
@@ -1,17 +1,19 @@
 module Client.App.Models
     exposing
-        ( Msg(DashBoardMsg, Refresh, OnLocation, FileTreeMsg)
+        ( Msg(DashBoardMsg, DependencyGraphMsg, Refresh, OnLocation, FileTreeMsg)
         , Model
-        , Content(DashBoardContent, FileTreeContent)
+        , Content(DashBoardContent, DependencyGraphContent, FileTreeContent)
         )
 
 import Client.DashBoard.DashBoard as DashBoard
+import Client.DependencyGraph.DependencyGraph as DependencyGraph
 import Client.FileTree as FileTree
 import Navigation exposing (Location)
 
 
 type Msg
     = DashBoardMsg DashBoard.Msg
+    | DependencyGraphMsg DependencyGraph.Msg
     | FileTreeMsg FileTree.Msg
     | Refresh
     | OnLocation Location
@@ -26,3 +28,4 @@ type alias Model =
 type Content
     = DashBoardContent DashBoard.Model
     | FileTreeContent FileTree.Model
+    | DependencyGraphContent DependencyGraph.Model

--- a/src/Client/App/Models.elm
+++ b/src/Client/App/Models.elm
@@ -1,19 +1,19 @@
 module Client.App.Models
     exposing
-        ( Msg(DashBoardMsg, DependencyGraphMsg, Refresh, OnLocation, FileTreeMsg)
+        ( Msg(DashBoardMsg, GraphMsg, Refresh, OnLocation, FileTreeMsg)
         , Model
-        , Content(DashBoardContent, DependencyGraphContent, FileTreeContent)
+        , Content(DashBoardContent, GraphContent, FileTreeContent)
         )
 
 import Client.DashBoard.DashBoard as DashBoard
-import Client.DependencyGraph.DependencyGraph as DependencyGraph
+import Client.Graph.Graph as Graph
 import Client.FileTree as FileTree
 import Navigation exposing (Location)
 
 
 type Msg
     = DashBoardMsg DashBoard.Msg
-    | DependencyGraphMsg DependencyGraph.Msg
+    | GraphMsg Graph.Msg
     | FileTreeMsg FileTree.Msg
     | Refresh
     | OnLocation Location
@@ -28,4 +28,4 @@ type alias Model =
 type Content
     = DashBoardContent DashBoard.Model
     | FileTreeContent FileTree.Model
-    | DependencyGraphContent DependencyGraph.Model
+    | GraphContent Graph.Model

--- a/src/Client/DependencyGraph/DependencyGraph.elm
+++ b/src/Client/DependencyGraph/DependencyGraph.elm
@@ -1,0 +1,57 @@
+module Client.DependencyGraph.DependencyGraph exposing (Model, Msg, subscriptions, init, update, view, withState)
+
+import Graph.GraphViz as GraphViz
+import Analyser.State as State exposing (State)
+import Client.Socket exposing (dashboardAddress)
+import Html exposing (Html, a, div, span, text)
+import Json.Decode as JD exposing (list, string)
+import Navigation exposing (Location)
+import WebSocket as WS
+
+
+type alias Model =
+    { state : Maybe State
+    }
+
+
+type Msg
+    = NewState (Result String State)
+
+
+subscriptions : Location -> Model -> Sub Msg
+subscriptions location model =
+    Sub.batch [ WS.listen (dashboardAddress location) (JD.decodeString State.decodeState >> NewState) ]
+
+
+withState : Maybe State -> Model -> Model
+withState x m =
+    { m | state = x }
+
+
+init : Location -> ( Model, Cmd Msg )
+init location =
+    { state = Nothing }
+        ! [ WS.send (dashboardAddress location) "ping"
+          ]
+
+
+update : Location -> Msg -> Model -> ( Model, Cmd Msg )
+update location msg model =
+    case msg of
+        NewState state ->
+            (withState (Result.toMaybe state) model) ! []
+
+
+view : Model -> Html Msg
+view m =
+    div []
+        [ case m.state of
+            Nothing ->
+                text "Loading..."
+
+            Just state ->
+                if State.isBusy state then
+                    text "Loading..."
+                else
+                    Html.pre [] [ text (GraphViz.string state.graph) ]
+        ]

--- a/src/Client/Graph/Graph.elm
+++ b/src/Client/Graph/Graph.elm
@@ -1,10 +1,10 @@
-module Client.DependencyGraph.DependencyGraph exposing (Model, Msg, subscriptions, init, update, view, withState)
+module Client.Graph.Graph exposing (Model, Msg, subscriptions, init, update, view, withState)
 
 import Graph.GraphViz as GraphViz
 import Analyser.State as State exposing (State)
 import Client.Socket exposing (dashboardAddress)
-import Html exposing (Html, a, div, span, text)
-import Json.Decode as JD exposing (list, string)
+import Html exposing (Html, div, text)
+import Json.Decode as JD
 import Navigation exposing (Location)
 import WebSocket as WS
 
@@ -19,7 +19,7 @@ type Msg
 
 
 subscriptions : Location -> Model -> Sub Msg
-subscriptions location model =
+subscriptions location _ =
     Sub.batch [ WS.listen (dashboardAddress location) (JD.decodeString State.decodeState >> NewState) ]
 
 
@@ -36,10 +36,10 @@ init location =
 
 
 update : Location -> Msg -> Model -> ( Model, Cmd Msg )
-update location msg model =
+update _ msg model =
     case msg of
         NewState state ->
-            (withState (Result.toMaybe state) model) ! []
+            withState (Result.toMaybe state) model ! []
 
 
 view : Model -> Html Msg

--- a/src/Graph.elm
+++ b/src/Graph.elm
@@ -1,0 +1,65 @@
+module Graph exposing (Graph, decode, encode, init, run)
+
+import Graph.Edge as Edge exposing (Edge)
+import Analyser.FileContext as FileContext exposing (FileContext)
+import Analyser.Files.Types exposing (Dependency, LoadedSourceFiles)
+import AST.Types as AST
+import Json.Decode as JD exposing (Decoder)
+import Json.Decode.Extra exposing ((|:))
+import Json.Encode as JE exposing (Value)
+
+
+type alias Graph =
+    { edges : List Edge
+    }
+
+
+init : List Edge -> Graph
+init =
+    Graph
+
+
+run : LoadedSourceFiles -> List Dependency -> Graph
+run sources deps =
+    let
+        files =
+            sources
+                |> List.filterMap (FileContext.create sources deps)
+    in
+        files
+            |> List.map runForFile
+            |> List.concat
+            |> init
+
+
+runForFile : FileContext -> List Edge
+runForFile file =
+    let
+        imports =
+            file.ast.imports
+                |> List.map .moduleName
+                |> List.map (Just >> stringFromModuleName)
+
+        from =
+            stringFromModuleName file.moduleName
+    in
+        List.map (\to -> Edge from to) imports
+
+
+stringFromModuleName : Maybe AST.ModuleName -> String
+stringFromModuleName moduleName =
+    Maybe.map (String.join ".") moduleName
+        |> Maybe.withDefault "Unknown"
+
+
+decode : Decoder Graph
+decode =
+    JD.succeed Graph
+        |: JD.field "edges" (JD.list Edge.decode)
+
+
+encode : Graph -> Value
+encode record =
+    JE.object
+        [ ( "edges", JE.list (List.map Edge.encode record.edges) )
+        ]

--- a/src/Graph/Edge.elm
+++ b/src/Graph/Edge.elm
@@ -1,0 +1,28 @@
+module Graph.Edge exposing (Edge, decode, encode)
+
+import Json.Encode as JE exposing (Value)
+import Json.Decode as JD exposing (Decoder)
+import Json.Decode.Extra exposing ((|:))
+
+
+{-| Describes the link between two nodes in a Graph.
+-}
+type alias Edge =
+    { from : String
+    , to : String
+    }
+
+
+decode : Decoder Edge
+decode =
+    JD.succeed Edge
+        |: JD.field "from" JD.string
+        |: JD.field "to" JD.string
+
+
+encode : Edge -> Value
+encode record =
+    JE.object
+        [ ( "from", JE.string <| record.from )
+        , ( "to", JE.string <| record.to )
+        ]

--- a/src/Graph/Edge.elm
+++ b/src/Graph/Edge.elm
@@ -1,16 +1,30 @@
-module Graph.Edge exposing (Edge, decode, encode)
+module Graph.Edge exposing (Edge, decode, encode, filterForIdentifiers)
 
+import Graph.Node as Node exposing (Node)
 import Json.Encode as JE exposing (Value)
 import Json.Decode as JD exposing (Decoder)
 import Json.Decode.Extra exposing ((|:))
+import Set exposing (Set)
 
 
 {-| Describes the link between two nodes in a Graph.
 -}
 type alias Edge =
-    { from : String
-    , to : String
+    { from : Node.Identifier
+    , to : Node.Identifier
     }
+
+
+{-| Filter list of edges to only include edges referencing a node in the
+given list. This is useful to exclude external nodes.
+-}
+filterForIdentifiers : Set Node.Identifier -> List Edge -> List Edge
+filterForIdentifiers identifiers =
+    List.filter
+        (\edge ->
+            Set.member edge.to identifiers
+                && Set.member edge.from identifiers
+        )
 
 
 decode : Decoder Edge
@@ -23,6 +37,6 @@ decode =
 encode : Edge -> Value
 encode record =
     JE.object
-        [ ( "from", JE.string <| record.from )
-        , ( "to", JE.string <| record.to )
+        [ ( "from", JE.string record.from )
+        , ( "to", JE.string record.to )
         ]

--- a/src/Graph/GraphViz.elm
+++ b/src/Graph/GraphViz.elm
@@ -62,5 +62,5 @@ node node =
         ++ " [shape=box "
         ++ style node
         ++ " label=\""
-        ++ (String.join "." node.name)
+        ++ String.join "." node.name
         ++ "\"];"

--- a/src/Graph/GraphViz.elm
+++ b/src/Graph/GraphViz.elm
@@ -1,0 +1,24 @@
+module Graph.GraphViz exposing (string)
+
+{-| Exports a Graph in GraphViz format.
+
+@see http://www.graphviz.org
+-}
+
+import Graph exposing (Graph)
+import Graph.Edge exposing (Edge)
+
+
+string : Graph -> String
+string graph =
+    let
+        edgesString =
+            List.map edge graph.edges
+                |> String.join ""
+    in
+        "digraph G { rankdir=TB " ++ edgesString ++ "} "
+
+
+edge : Edge -> String
+edge { from, to } =
+    toString from ++ " -> " ++ toString to ++ ";\n"

--- a/src/Graph/GraphViz.elm
+++ b/src/Graph/GraphViz.elm
@@ -6,19 +6,61 @@ module Graph.GraphViz exposing (string)
 -}
 
 import Graph exposing (Graph)
-import Graph.Edge exposing (Edge)
+import Graph.Edge as Edge exposing (Edge)
+import Graph.Node exposing (Node)
+import Set
 
 
 string : Graph -> String
 string graph =
     let
+        identifiers =
+            -- external node are not correctly rendered by GraphViz
+            -- (we exclude them below)
+            List.map .identifier graph.nodes
+                |> Set.fromList
+
         edgesString =
-            List.map edge graph.edges
-                |> String.join ""
+            Edge.filterForIdentifiers identifiers graph.edges
+                |> List.map edge
+                |> String.join "\n"
+
+        nodesString =
+            List.map node graph.nodes
+                |> String.join "\n"
     in
-        "digraph G { rankdir=TB " ++ edgesString ++ "} "
+        "digraph G { rankdir=TB \n" ++ nodesString ++ edgesString ++ "} "
 
 
 edge : Edge -> String
 edge { from, to } =
-    toString from ++ " -> " ++ toString to ++ ";\n"
+    toString from ++ " -> " ++ toString to ++ ";"
+
+
+style : Node -> String
+style node =
+    let
+        numNameElements =
+            List.length node.name
+    in
+        if numNameElements == 1 then
+            "style=\"bold, filled\" fillColor=\"#ddd\""
+        else if numNameElements <= 2 then
+            "style=bold"
+        else if numNameElements <= 3 then
+            "style=solid"
+        else if numNameElements <= 5 then
+            "style=dashed"
+        else
+            "style=dotted"
+
+
+node : Node -> String
+node node =
+    -- wrapp string in quotes
+    toString node.identifier
+        ++ " [shape=box "
+        ++ style node
+        ++ " label=\""
+        ++ (String.join "." node.name)
+        ++ "\"];"

--- a/src/Graph/Node.elm
+++ b/src/Graph/Node.elm
@@ -1,0 +1,32 @@
+module Graph.Node exposing (Node, Identifier, decode, encode)
+
+import Json.Encode as JE exposing (Value)
+import Json.Decode as JD exposing (Decoder)
+import Json.Decode.Extra exposing ((|:))
+
+
+type alias Identifier =
+    String
+
+
+{-| Describes a node in a graph.
+-}
+type alias Node =
+    { identifier : Identifier
+    , name : List String
+    }
+
+
+decode : Decoder Node
+decode =
+    JD.succeed Node
+        |: JD.field "identifier" JD.string
+        |: JD.field "name" (JD.list JD.string)
+
+
+encode : Node -> Value
+encode record =
+    JE.object
+        [ ( "identifier", JE.string record.identifier )
+        , ( "name", JE.list (List.map JE.string record.name) )
+        ]


### PR DESCRIPTION
This adds the first steps towards an integrated module hierarchy visualisation and right now provides a [Graphviz](http://graphviz.org) representation as code in the web UI. 

Before finally closing this PR I will add comments and docs once we agreed on the module structure.

The next steps will be:

- [ ] Add (interactive) visualisation in web UI  (I would keep the code export as this allows users to include this in readmes, etc.)
- [ ] Add more information about the modules to the graph 
- [ ] Further down the road: Add more exports such as Netjson.org