### PR TITLE
use proper names for log/crash

### DIFF
--- a/src/Analyser/Messages/Util.elm
+++ b/src/Analyser/Messages/Util.elm
@@ -255,7 +255,7 @@ getMessageInfo m =
 
         DebugLog fileName range ->
             ( String.concat
-                [ "Use of debug log in file \""
+                [ "Use of Debug.log in file \""
                 , fileName
                 , "\" at "
                 , rangeToString range
@@ -267,7 +267,7 @@ getMessageInfo m =
 
         DebugCrash fileName range ->
             ( String.concat
-                [ "Use of debug crash in file \""
+                [ "Use of Debug.crash in file \""
                 , fileName
                 , "\" at "
                 , rangeToString range


### PR DESCRIPTION
When looking at the output from when I had some code with `Debug.crash` in, I was surprised to see the error `debug crash in file..`, because my brain did not parse it as `Debug.crash`. I think it's best to keep the error to match the code as closely as possible -- then I know what to ctrl+f for :)