### PR TITLE
DependencyLoader output separates name and version

### DIFF
--- a/src/Analyser/Files/DependencyLoader.elm
+++ b/src/Analyser/Files/DependencyLoader.elm
@@ -55,7 +55,7 @@ init ( name, version ) =
       }
     , Cmd.batch
         [ loadRawDependency ( name, version )
-        , Logger.info ("Load dependency " ++ name ++ version)
+        , Logger.info ("Load dependency " ++ name ++ " " ++ version)
         ]
     )
 


### PR DESCRIPTION
Added a minor change to put a space between the loaded dependency name and version.

#### Before

> INFO: Load dependency elm-community/dict-extra2.2.0
> INFO: Load dependency elm-community/list-extra6.1.0
> INFO: Load dependency elm-lang/animation-frame1.0.1
> INFO: Load dependency elm-lang/core5.1.1
> INFO: Load dependency elm-lang/geolocation1.0.2
> INFO: Load dependency elm-lang/html2.0.0
> INFO: Load dependency elm-lang/http1.0.0
> INFO: Load dependency elm-lang/svg2.0.0
> INFO: Load dependency elm-lang/websocket1.0.2
> INFO: Load dependency elm-lang/window1.0.1

#### After

> INFO: Load dependency elm-community/dict-extra 2.2.0
> INFO: Load dependency elm-community/list-extra 6.1.0
> INFO: Load dependency elm-lang/animation-frame 1.0.1
> INFO: Load dependency elm-lang/core 5.1.1
> INFO: Load dependency elm-lang/geolocation 1.0.2
> INFO: Load dependency elm-lang/html 2.0.0
> INFO: Load dependency elm-lang/http 1.0.0
> INFO: Load dependency elm-lang/svg 2.0.0
> INFO: Load dependency elm-lang/websocket 1.0.2
> INFO: Load dependency elm-lang/window 1.0.1

