### PR TITLE
Implement auto-fix for NoUncurriedPrefix

### DIFF
--- a/src/Analyser/Fixes/FileContent.elm
+++ b/src/Analyser/Fixes/FileContent.elm
@@ -1,4 +1,4 @@
-module Analyser.Fixes.FileContent exposing (getCharAtLocation, replaceLines, replaceLocationWith, replaceRangeWith, updateRange)
+module Analyser.Fixes.FileContent exposing (getCharAtLocation, getStringAtRange, replaceLines, replaceLocationWith, replaceRangeWith, updateRange)
 
 import Elm.Syntax.Range exposing (Range)
 import List.Extra as List
@@ -90,6 +90,30 @@ getCharAtLocation ( row, column ) input =
         |> List.drop row
         |> List.head
         |> Maybe.map (String.dropLeft column >> String.left 1)
+
+
+getStringAtRange : Range -> String -> String
+getStringAtRange { start, end } input =
+    let
+        trimLast i line =
+            if i == end.row then
+                String.left end.column line
+            else
+                line
+
+        trimFirst i line =
+            if i == 0 then
+                String.dropLeft start.column line
+            else
+                line
+    in
+    input
+        |> String.split "\n"
+        |> List.take (end.row + 1)
+        |> List.indexedMap trimLast
+        |> List.drop start.row
+        |> List.indexedMap trimFirst
+        |> String.concat
 
 
 replaceLines : ( Int, Int ) -> String -> String -> String

--- a/src/Analyser/Fixes/NoUncurriedPrefix.elm
+++ b/src/Analyser/Fixes/NoUncurriedPrefix.elm
@@ -1,0 +1,64 @@
+module Analyser.Fixes.NoUncurriedPrefix exposing (fixer)
+
+import Analyser.Checks.NoUncurriedPrefix as NoUncurriedPrefixCheck
+import Analyser.Fixes.Base exposing (Fixer, Patch(..))
+import Analyser.Fixes.FileContent as FileContent
+import Analyser.Messages.Data as Data exposing (MessageData)
+import Elm.Syntax.File exposing (File)
+import Elm.Syntax.Module exposing (Module(..))
+import Elm.Syntax.Range as Range exposing (Range)
+import Regex
+
+
+fixer : Fixer
+fixer =
+    Fixer (.key <| .info <| NoUncurriedPrefixCheck.checker) fix "Reorder and format"
+
+
+fix : ( String, File ) -> MessageData -> Patch
+fix input messageData =
+    case
+        Maybe.map3 (,,)
+            (Data.getRange "range" messageData)
+            (Data.getRange "arg1" messageData)
+            (Data.getRange "arg2" messageData)
+    of
+        Just ( range, argRange1, argRange2 ) ->
+            updateExpression input ( range, argRange1, argRange2 )
+
+        Nothing ->
+            IncompatibleData
+
+
+parenRegex : Regex.Regex
+parenRegex =
+    Regex.regex "[()]"
+
+
+updateExpression : ( String, File ) -> ( Range, Range, Range ) -> Patch
+updateExpression ( content, _ ) ( opRange, argRange1, argRange2 ) =
+    let
+        op =
+            FileContent.getStringAtRange opRange content
+                -- Drop the surrounding parens
+                |> Regex.replace Regex.All parenRegex (\_ -> "")
+
+        arg1 =
+            FileContent.getStringAtRange argRange1 content
+
+        arg2 =
+            FileContent.getStringAtRange argRange2 content
+
+        range =
+            Range.combine [ opRange, argRange2 ]
+    in
+    if op == "," then
+        -- Special case for the two-tuple operator, which needs surrounding parens
+        content
+            |> FileContent.replaceRangeWith range ("(" ++ arg1 ++ ", " ++ arg2 ++ ")")
+            |> Patched
+    else
+        -- Normal case for all other operators
+        content
+            |> FileContent.replaceRangeWith range (arg1 ++ " " ++ op ++ " " ++ arg2)
+            |> Patched

--- a/src/Analyser/Messages/Data.elm
+++ b/src/Analyser/Messages/Data.elm
@@ -1,4 +1,4 @@
-module Analyser.Messages.Data exposing (MessageData, addErrorMessage, addFileName, addModuleName, addRange, addRanges, addVarName, conformToSchema, decode, description, encode, firstRange, getRange, getRanges, init, withDescription)
+module Analyser.Messages.Data exposing (MessageData, addErrorMessage, addFileName, addModuleName, addRange, addRanges, addVarName, conformToSchema, decode, description, encode, firstRange, getRange, getRangeList, getRanges, init, withDescription)
 
 import Analyser.Messages.Schema as Schema exposing (Schema)
 import Dict exposing (Dict)
@@ -219,10 +219,25 @@ getRange k (MessageData _ d) =
     Dict.get k d |> Maybe.andThen valueAsRange
 
 
+getRangeList : String -> MessageData -> Maybe (List Range)
+getRangeList k (MessageData _ d) =
+    Dict.get k d |> Maybe.andThen valueAsRangeList
+
+
 valueAsRange : DataValue -> Maybe Range
 valueAsRange dv =
     case dv of
         RangeV v ->
+            Just v
+
+        _ ->
+            Nothing
+
+
+valueAsRangeList : DataValue -> Maybe (List Range)
+valueAsRangeList dv =
+    case dv of
+        RangeListV v ->
             Just v
 
         _ ->

--- a/tests/Analyser/Checks/NoUncurriedPrefixTests.elm
+++ b/tests/Analyser/Checks/NoUncurriedPrefixTests.elm
@@ -17,6 +17,10 @@ foo = (+) 1 2
             |> Data.addVarName "varName" "+"
             |> Data.addRange "range"
                 { start = { row = 2, column = 6 }, end = { row = 2, column = 9 } }
+            |> Data.addRange "arg1"
+                { start = { row = 2, column = 10 }, end = { row = 2, column = 11 } }
+            |> Data.addRange "arg2"
+                { start = { row = 2, column = 12 }, end = { row = 2, column = 13 } }
       ]
     )
 
@@ -34,10 +38,24 @@ foo = (+) 1
     )
 
 
+threeTupleAsApplicationWithTwoArgs : ( String, String, List MessageData )
+threeTupleAsApplicationWithTwoArgs =
+    ( "threeTupleAsApplicationWithTwoArgs"
+    , """module Foo exposing (..)
+
+
+foo = (,,) 1 2
+
+"""
+    , []
+    )
+
+
 all : Test
 all =
     CTU.build "Analyser.Checks.NoUncurriedPrefix"
         NoUncurriedPrefix.checker
         [ prefixAsApplicationWithTwoArgs
         , prefixAsApplicationWithOneArg
+        , threeTupleAsApplicationWithTwoArgs
         ]

--- a/tests/Analyser/Fixes/NoUncurriedPrefixTests.elm
+++ b/tests/Analyser/Fixes/NoUncurriedPrefixTests.elm
@@ -1,0 +1,44 @@
+module Analyser.Fixes.NoUncurriedPrefixTests exposing (all)
+
+import Analyser.Checks.NoUncurriedPrefix
+import Analyser.Fixes.NoUncurriedPrefix
+import Analyser.Fixes.TestUtil exposing (testFix)
+import Test exposing (Test, only)
+
+
+prefixAsApplicationWithTwoArgs : ( String, String, String )
+prefixAsApplicationWithTwoArgs =
+    ( "prefixAsApplicationWithTwoArgs"
+    , """module Foo exposing (..)
+
+foo = (+) 1 2
+"""
+    , """module Foo exposing (..)
+
+foo = 1 + 2
+"""
+    )
+
+
+twoTupleAsApplicationWithTwoArgs : ( String, String, String )
+twoTupleAsApplicationWithTwoArgs =
+    ( "twoTupleAsApplicationWithTwoArgs"
+    , """module Foo exposing (..)
+
+foo = (,) 1 2
+"""
+    , """module Foo exposing (..)
+
+foo = (1, 2)
+"""
+    )
+
+
+all : Test
+all =
+    testFix "Analyser.Fixes.NoUncurriedPrefix"
+        Analyser.Checks.NoUncurriedPrefix.checker
+        Analyser.Fixes.NoUncurriedPrefix.fixer
+        [ prefixAsApplicationWithTwoArgs
+        , twoTupleAsApplicationWithTwoArgs
+        ]


### PR DESCRIPTION
Ticks a box on issue #5.

I added a couple of helper functions: `FileContent.getStringAtRange` and `Data.getRangeList`. I couldn't find any existing functions that did what I was needed.