### PR TITLE
Add auto-fix for DropConsOfItemAndList

### DIFF
--- a/src/Analyser/Checks/DropConsOfItemAndList.elm
+++ b/src/Analyser/Checks/DropConsOfItemAndList.elm
@@ -21,8 +21,8 @@ checker =
         , schema =
             Schema.schema
                 |> Schema.rangeProp "range"
-                |> Schema.rangeProp "car"
-                |> Schema.rangeProp "cdr"
+                |> Schema.rangeProp "head"
+                |> Schema.rangeProp "tail"
         }
     }
 
@@ -56,8 +56,8 @@ onExpression ( r, inner ) context =
                     ]
                 )
                 |> Data.addRange "range" range
-                |> Data.addRange "car" carRange
-                |> Data.addRange "cdr" cdrRange
+                |> Data.addRange "head" carRange
+                |> Data.addRange "tail" cdrRange
             )
                 :: context
 

--- a/src/Analyser/Checks/DropConsOfItemAndList.elm
+++ b/src/Analyser/Checks/DropConsOfItemAndList.elm
@@ -17,10 +17,12 @@ checker =
     , info =
         { key = "DropConsOfItemAndList"
         , name = "Drop Cons Of Item And List"
-        , description = "If you cons an item to a literal list (x :x [1, 2, 3]), then you can just put the item into the list."
+        , description = "If you cons an item to a literal list (x :: [1, 2, 3]), then you can just put the item into the list."
         , schema =
             Schema.schema
                 |> Schema.rangeProp "range"
+                |> Schema.rangeProp "car"
+                |> Schema.rangeProp "cdr"
         }
     }
 
@@ -42,7 +44,7 @@ scan fileContext _ =
 onExpression : Ranged Expression -> Context -> Context
 onExpression ( r, inner ) context =
     case inner of
-        OperatorApplication "::" _ _ ( _, ListExpr _ ) ->
+        OperatorApplication "::" _ ( carRange, _ ) ( cdrRange, ListExpr _ ) ->
             let
                 range =
                     r
@@ -54,6 +56,8 @@ onExpression ( r, inner ) context =
                     ]
                 )
                 |> Data.addRange "range" range
+                |> Data.addRange "car" carRange
+                |> Data.addRange "cdr" cdrRange
             )
                 :: context
 

--- a/src/Analyser/Checks/DropConsOfItemAndList.elm
+++ b/src/Analyser/Checks/DropConsOfItemAndList.elm
@@ -44,7 +44,7 @@ scan fileContext _ =
 onExpression : Ranged Expression -> Context -> Context
 onExpression ( r, inner ) context =
     case inner of
-        OperatorApplication "::" _ ( carRange, _ ) ( cdrRange, ListExpr _ ) ->
+        OperatorApplication "::" _ ( headRange, _ ) ( tailRange, ListExpr _ ) ->
             let
                 range =
                     r
@@ -56,8 +56,8 @@ onExpression ( r, inner ) context =
                     ]
                 )
                 |> Data.addRange "range" range
-                |> Data.addRange "head" carRange
-                |> Data.addRange "tail" cdrRange
+                |> Data.addRange "head" headRange
+                |> Data.addRange "tail" tailRange
             )
                 :: context
 

--- a/src/Analyser/Fixers.elm
+++ b/src/Analyser/Fixers.elm
@@ -1,6 +1,7 @@
 module Analyser.Fixers exposing (all, getFixer)
 
 import Analyser.Fixes.Base exposing (Fixer)
+import Analyser.Fixes.DropConsOfItemAndList as DropConsOfItemAndList
 import Analyser.Fixes.MultiLineRecordFormatting as MultiLineRecordFormatting
 import Analyser.Fixes.UnformattedFile as UnformattedFileFixer
 import Analyser.Fixes.UnnecessaryParens as UnnecessaryParensFixer
@@ -26,4 +27,5 @@ all =
     , UnformattedFileFixer.fixer
     , UnusedTypeAliasFixer.fixer
     , MultiLineRecordFormatting.fixer
+    , DropConsOfItemAndList.fixer
     ]

--- a/src/Analyser/Fixes/DropConsOfItemAndList.elm
+++ b/src/Analyser/Fixes/DropConsOfItemAndList.elm
@@ -1,0 +1,44 @@
+module Analyser.Fixes.DropConsOfItemAndList exposing (fixer)
+
+import Analyser.Checks.DropConsOfItemAndList as DropConsOfItemAndListCheck
+import Analyser.Fixes.Base exposing (Fixer)
+import Analyser.Fixes.FileContent as FileContent
+import Analyser.Messages.Data as Data exposing (MessageData)
+import Elm.Syntax.File exposing (File)
+import Elm.Syntax.Range exposing (Range)
+
+
+fixer : Fixer
+fixer =
+    Fixer (.key <| .info <| DropConsOfItemAndListCheck.checker)
+        fix
+        "Combine and format"
+
+
+fix : ( String, File ) -> MessageData -> Result String String
+fix ( content, _ ) messageData =
+    case
+        ( Data.getRange "car" messageData
+        , Data.getRange "cdr" messageData
+        )
+    of
+        ( Just carRange, Just cdrRange ) ->
+            fixContent carRange cdrRange content |> Ok
+
+        _ ->
+            Err "Invalid message data for fixer UnnecessaryParens"
+
+
+fixContent : Range -> Range -> String -> String
+fixContent carRange cdrRange content =
+    let
+        middleRange =
+            { start = carRange.end, end = cdrRange.start }
+    in
+    content
+        -- Drop the opening `[`
+        |> FileContent.updateRange cdrRange (String.dropLeft 1)
+        -- Replace the `::`
+        |> FileContent.replaceRangeWith middleRange ","
+        -- Add new opening `[`
+        |> FileContent.updateRange carRange (String.append "[ ")

--- a/src/Analyser/Fixes/DropConsOfItemAndList.elm
+++ b/src/Analyser/Fixes/DropConsOfItemAndList.elm
@@ -18,27 +18,27 @@ fixer =
 fix : ( String, File ) -> MessageData -> Result String String
 fix ( content, _ ) messageData =
     case
-        ( Data.getRange "car" messageData
-        , Data.getRange "cdr" messageData
-        )
+        Maybe.map2 (,)
+            (Data.getRange "head" messageData)
+            (Data.getRange "tail" messageData)
     of
-        ( Just carRange, Just cdrRange ) ->
-            fixContent carRange cdrRange content |> Ok
+        Just ( headRange, tailRange ) ->
+            fixContent headRange tailRange content |> Ok
 
-        _ ->
-            Err "Invalid message data for fixer UnnecessaryParens"
+        Nothing ->
+            Err "Invalid message data for fixer DropConsOfItemAndList"
 
 
 fixContent : Range -> Range -> String -> String
-fixContent carRange cdrRange content =
+fixContent headRange tailRange content =
     let
         middleRange =
-            { start = carRange.end, end = cdrRange.start }
+            { start = headRange.end, end = tailRange.start }
     in
     content
         -- Drop the opening `[`
-        |> FileContent.updateRange cdrRange (String.dropLeft 1)
+        |> FileContent.updateRange tailRange (String.dropLeft 1)
         -- Replace the `::`
         |> FileContent.replaceRangeWith middleRange ","
         -- Add new opening `[`
-        |> FileContent.updateRange carRange (String.append "[ ")
+        |> FileContent.updateRange headRange (String.append "[ ")

--- a/src/Analyser/Fixes/FileContent.elm
+++ b/src/Analyser/Fixes/FileContent.elm
@@ -4,8 +4,8 @@ import Elm.Syntax.Range exposing (Range)
 import List.Extra as List
 
 
-updateRange : Range -> String -> (String -> String) -> String
-updateRange range content patch =
+updateRange : Range -> (String -> String) -> String -> String
+updateRange range patch content =
     let
         rows =
             content
@@ -24,7 +24,7 @@ updateRange range content patch =
             String.left range.start.column
 
         rowPostPartTakeFn =
-            String.dropLeft (range.end.column + 1)
+            String.dropLeft range.end.column
 
         rowPrePart =
             List.drop beforeRows rows
@@ -61,7 +61,7 @@ updateRange range content patch =
 
 replaceRangeWith : Range -> String -> String -> String
 replaceRangeWith range newValue input =
-    updateRange range input (always newValue)
+    updateRange range (always newValue) input
 
 
 replaceLocationWith : ( Int, Int ) -> String -> String -> String

--- a/src/Analyser/Fixes/MultiLineRecordFormatting.elm
+++ b/src/Analyser/Fixes/MultiLineRecordFormatting.elm
@@ -37,7 +37,7 @@ replacement { match } =
 
 fixContent : Range -> String -> String
 fixContent range content =
-    FileContent.updateRange
-        range
-        content
-        (Regex.replace (Regex.AtMost 1) commaAndIdentifierRegex replacement)
+    content
+        |> FileContent.updateRange
+            range
+            (Regex.replace (Regex.AtMost 1) commaAndIdentifierRegex replacement)

--- a/tests/Analyser/Checks/DropConsOfItemAndListTests.elm
+++ b/tests/Analyser/Checks/DropConsOfItemAndListTests.elm
@@ -31,9 +31,9 @@ foo =
     , [ Data.init "foo"
             |> Data.addRange "range"
                 { start = { row = 4, column = 4 }, end = { row = 4, column = 16 } }
-            |> Data.addRange "car"
+            |> Data.addRange "head"
                 { start = { row = 4, column = 4 }, end = { row = 4, column = 5 } }
-            |> Data.addRange "cdr"
+            |> Data.addRange "tail"
                 { start = { row = 4, column = 9 }, end = { row = 4, column = 16 } }
       ]
     )

--- a/tests/Analyser/Checks/DropConsOfItemAndListTests.elm
+++ b/tests/Analyser/Checks/DropConsOfItemAndListTests.elm
@@ -31,6 +31,10 @@ foo =
     , [ Data.init "foo"
             |> Data.addRange "range"
                 { start = { row = 4, column = 4 }, end = { row = 4, column = 16 } }
+            |> Data.addRange "car"
+                { start = { row = 4, column = 4 }, end = { row = 4, column = 5 } }
+            |> Data.addRange "cdr"
+                { start = { row = 4, column = 9 }, end = { row = 4, column = 16 } }
       ]
     )
 

--- a/tests/Analyser/Fixes/DropConsOfItemAndListTests.elm
+++ b/tests/Analyser/Fixes/DropConsOfItemAndListTests.elm
@@ -1,0 +1,72 @@
+module Analyser.Fixes.DropConsOfItemAndListTests exposing (all)
+
+import Analyser.Checks.DropConsOfItemAndList exposing (checker)
+import Analyser.Fixes.DropConsOfItemAndList exposing (fixer)
+import Analyser.Fixes.TestUtil exposing (testFix)
+import Test exposing (Test, only)
+
+
+consWithLiteralList : ( String, String, String )
+consWithLiteralList =
+    ( "consWithLiteralList"
+    , """module Bar exposing (foo)
+
+foo : Int
+foo =
+    1 :: [ 2, 3]
+"""
+    , """module Bar exposing (foo)
+
+foo : Int
+foo =
+    [ 1, 2, 3]
+"""
+    )
+
+
+separateLines : ( String, String, String )
+separateLines =
+    ( "separateLines"
+    , """module Bar exposing (foo)
+
+foo : Int
+foo =
+    1
+        :: [ 2, 3]
+"""
+    , """module Bar exposing (foo)
+
+foo : Int
+foo =
+    [ 1, 2, 3]
+"""
+    )
+
+
+itemsWithSubLists : ( String, String, String )
+itemsWithSubLists =
+    ( "itemsWithSubLists"
+    , """module Bar exposing (foo)
+
+foo : Int
+foo =
+    [ 1, 2 ] :: [ [ 3, 4 ], [ 5, 6 ] ]
+"""
+    , """module Bar exposing (foo)
+
+foo : Int
+foo =
+    [ [ 1, 2 ], [ 3, 4 ], [ 5, 6 ] ]
+"""
+    )
+
+
+all : Test
+all =
+    testFix "Analyser.Fixes.DropConsOfItemAndList"
+        checker
+        fixer
+        [ consWithLiteralList
+        , separateLines
+        , itemsWithSubLists
+        ]

--- a/tests/Analyser/Fixes/FileContentTests.elm
+++ b/tests/Analyser/Fixes/FileContentTests.elm
@@ -12,28 +12,28 @@ all =
             [ test "onSingleLine" <|
                 \() ->
                     FileContent.replaceRangeWith
-                        { start = { row = 1, column = 6 }, end = { row = 1, column = 8 } }
+                        { start = { row = 1, column = 6 }, end = { row = 1, column = 9 } }
                         "FOO"
                         "abcdefghijk\n1234567890\nabcdefghijk"
                         |> Expect.equal "abcdefghijk\n123456FOO0\nabcdefghijk"
             , test "onMultiline" <|
                 \() ->
                     FileContent.replaceRangeWith
-                        { start = { row = 1, column = 6 }, end = { row = 2, column = 6 } }
+                        { start = { row = 1, column = 6 }, end = { row = 2, column = 7 } }
                         "FOO"
                         "abcdefghijk\n1234567890\nabcdefghijk"
                         |> Expect.equal "abcdefghijk\n123456FOOhijk"
             , test "onNextlineButStart" <|
                 \() ->
                     FileContent.replaceRangeWith
-                        { start = { row = 1, column = 6 }, end = { row = 1, column = 12 } }
+                        { start = { row = 1, column = 6 }, end = { row = 1, column = 13 } }
                         "FOO"
                         "abcdefghijk\n1234567890\nabcdefghijk"
                         |> Expect.equal "abcdefghijk\n123456FOO\nabcdefghijk"
             , test "onNextlineButStart2" <|
                 \() ->
                     FileContent.replaceRangeWith
-                        { start = { row = 1, column = 6 }, end = { row = 2, column = 0 } }
+                        { start = { row = 1, column = 6 }, end = { row = 2, column = 1 } }
                         "FOO"
                         "abcdefghijk\n1234567890\nabcdefghijk"
                         |> Expect.equal "abcdefghijk\n123456FOObcdefghijk"


### PR DESCRIPTION
Another box on #5 

I also modified `FileContent.updateRange` to treat ranges as [inclusive, exclusive), which feels more natural - for example, if you use the end of one range as the start of another, then they don't overlap.