### PR TITLE
Filename in title of ui modal

### DIFF
--- a/src/Client/Components/ActiveMessageDialog.elm
+++ b/src/Client/Components/ActiveMessageDialog.elm
@@ -114,7 +114,7 @@ dialogConfig : State -> Config Msg
 dialogConfig state =
     { closeMessage = Just Close
     , containerClass = Just "message-dialog"
-    , header = Just dialogHeader
+    , header = Just <| dialogHeader state
     , body = Just <| dialogBody state
     , footer = Just (footer state.message)
     }
@@ -157,13 +157,17 @@ dialogBody state =
 
 viewWithFileContent : State -> String -> Html msg
 viewWithFileContent state x =
-    div [ style [ ( "max-height", "400px" ), ( "overflow", "scroll" ) ] ]
+    div [ style [ ( "max-height", "400px" ), ( "overflow", "auto" ) ] ]
         [ div []
             (List.map (Highlight.highlightedPre 3 x) state.ranges)
         , text <| Data.description state.message.data
         ]
 
 
-dialogHeader : Html msg
-dialogHeader =
-    h3 [] [ text "Message" ]
+dialogHeader : State -> Html msg
+dialogHeader state =
+    let
+        filePath =
+            state.message.file.path
+    in
+    h3 [] [ text <| "Message (" ++ filePath ++ ")" ]


### PR DESCRIPTION
I added a change to show the file name. With the change it would look like this.

![screenshot from 2018-07-25 19-54-09](https://user-images.githubusercontent.com/13085980/43218657-499d4834-9045-11e8-9296-94abff4c984d.png)

Side question: How about  adding those files to `.gitignore`:
```elm
    modified:   js/backend-elm.js                                                          
    modified:   js/public/client-elm.js
```

Solves #171 