### PR TITLE
Problem: Running `make` fails due to missing npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ws": "3.3.1"
   },
   "devDependencies": {
+    "@types/body-parser": "^1.17.0",
     "@types/express": "^4.16.0",
     "@types/express-ws": "^3.0.0",
     "@types/find": "^0.2.0",
@@ -64,6 +65,9 @@
     "@types/os-homedir": "^1.0.0",
     "@types/request": "^2.47.1",
     "@types/ws": "^5.1.2",
+    "async-limiter": "^1.0.0",
+    "bindings": "^1.3.0",
+    "body-parser": "^1.18.3",
     "bootstrap": "^3.3.7",
     "bufferutil": "3.0.3",
     "chokidar": "1.7.0",
@@ -83,6 +87,7 @@
     "run-sequence": "1.2.2",
     "sb-admin-2": "^3.3.8",
     "typescript": "^2.9.2",
+    "ultron": "^1.1.1",
     "utf-8-validate": "3.0.4"
   }
 }


### PR DESCRIPTION
Solution: Added missing packages to package.json file

Note: These were the errors I got when running `make`, each followed by the command I ran to add the missing dependency.

<details>
  <summary>Click to expand</summary>

<hr/>

<code>
ts/server/app.ts:11:29 - error TS2307: Cannot find module 'body-parser'.

11 import * as bodyParser from 'body-parser';
</code>

Fixed with: <pre>npm install --save-dev body-parser</pre>

<hr/>

<code>
ts/server/app.ts:11:29 - error TS7016: Could not find a declaration file for module 'body-parser'. '~/dev/elm/reference/elm-analyse/node_modules/.registry.npmjs.org/body-parser/1.18.3/node_modules/body-parser/index.js' implicitly has an 'any' type.
  Try `npm install @types/body-parser` if it exists or add a new declaration (.d.ts) file containing `declare module 'body-parser';`

11 import * as bodyParser from 'body-parser';
</code>

Fixed with: <pre>npm install --save-dev @types/body-parser</pre>

<hr/>

<code>
{ Error: Cannot find module 'ultron' from '~/dev/elm/reference/elm-analyse/node_modules/ws/lib'
</code>

Fixed with: <pre>npm install --save-dev ultron</pre>

<hr/>

<code>
{ Error: Cannot find module 'async-limiter' from '~/dev/elm/reference/elm-analyse/node_modules/ws/lib'
</code>

Fixed with: <pre>npm install --save-dev async-limiter</pre>

<hr/>

<code>
{ Error: Cannot find module 'async-limiter' from '~/dev/elm/reference/elm-analyse/node_modules/ws/lib'
</code>

Fixed with: <pre>npm install --save-dev async-limiter</pre>

<hr/>

<code>
{ Error: Cannot find module 'bindings' from '~/dev/elm/reference/elm-analyse/node_modules/utf-8-validate'</code>

Fixed with: <pre>npm install --save-dev bindings</pre>

</details>