### PR TITLE
Language Server Diagnostics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Add the `-s` option for server mode. This will allow you to view results in your
 | ------ | ----------- |
 | `--help or -h`          | Print the help output. |
 | `--serve or -s`         | Enable server mode. Disabled by default. |
+| `--lsp or -l`           | Enable language server mode. Disabled by default. You must also specify one of: `--stdio`, `--node-ipc`, or `--socket={number}` for the communication method to use. |
 | `--port or -p`          | The port on which the server should listen. Defaults to 3000 (`--port=3000`). |
 | `--open or -o`          | Open default browser when server goes live. |
 | `--elm-format-path`     | Path to elm-format. Defaults to `elm-format`. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-analyse",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9617,6 +9617,39 @@
           }
         }
       }
+    },
+    "vscode-jsonrpc": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
+      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
+    },
+    "vscode-languageserver": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-5.2.1.tgz",
+      "integrity": "sha512-GuayqdKZqAwwaCUjDvMTAVRPJOp/SLON3mJ07eGsx/Iq9HjRymhKWztX41rISqDKhHVVyFM+IywICyZDla6U3A==",
+      "requires": {
+        "vscode-languageserver-protocol": "3.14.1",
+        "vscode-uri": "^1.0.6"
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
+      "integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
+      "requires": {
+        "vscode-jsonrpc": "^4.0.0",
+        "vscode-languageserver-types": "3.14.0"
+      }
+    },
+    "vscode-languageserver-types": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
+      "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
+    },
+    "vscode-uri": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz",
+      "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "os-homedir": "1.0.2",
     "request": "2.88.0",
     "sums": "0.2.4",
+    "vscode-languageserver": "^5.2.1",
     "ws": "3.3.1"
   },
   "devDependencies": {

--- a/ts/bin/index.ts
+++ b/ts/bin/index.ts
@@ -4,17 +4,19 @@ import minimist from 'minimist';
 import * as fs from 'fs';
 import * as path from 'path';
 import Server from '../server/app';
+import LSPServer from '../server/language-server';
 import Analyser from '../analyser';
 
 var args = minimist(process.argv.slice(2), {
     alias: {
         serve: 's',
+        lsp: 'l',
         help: 'h',
         port: 'p',
         version: 'v',
         open: 'o'
     },
-    boolean: ['serve', 'help', 'version', 'open'],
+    boolean: ['lsp', 'serve', 'help', 'version', 'open'],
     string: ['port', 'elm-format-path', 'format']
 });
 
@@ -49,6 +51,9 @@ var args = minimist(process.argv.slice(2), {
         console.log('   --help, -h          Print the help output.');
         console.log('   --serve, -s         Enable server mode. Disabled by default.');
         console.log('   --port, -p          The port on which the server should listen. Defaults to 3000.');
+        console.log('   --lsp, -l           Enable language server mode. Disabled by default.');
+        console.log('                       You must also specify one of: "--stdio", "--node-ipc",');
+        console.log('                       or "--socket={number}" for the communication method to use.');
         console.log('   --open, -o          Open default browser when server goes live.');
         console.log('   --elm-format-path   Path to elm-format. Defaults to `elm-format`.');
         console.log('   --format            Output format for CLI. Defaults to "human". Options "human"|"json"');
@@ -70,6 +75,9 @@ var args = minimist(process.argv.slice(2), {
 
     if (args.serve) {
         Server.start(config, info, projectFile);
+        return;
+    } else if (args.lsp) {
+        LSPServer.start(config, info, projectFile);
         return;
     }
     Analyser.start(config, projectFile);

--- a/ts/domain.ts
+++ b/ts/domain.ts
@@ -151,7 +151,7 @@ interface FileRef {
 interface Message {
     id: number;
     status: string;
-    file: FileRef;
+    file: string;
     type: string;
     data: MessageData;
 }

--- a/ts/server/language-server.ts
+++ b/ts/server/language-server.ts
@@ -14,6 +14,10 @@ import {
 } from 'vscode-languageserver';
 
 function start(config: Config, info: Info, project: {}) {
+    // Disable console logging while in language server mode
+    // otherwise in stdio mode we will not be sending valid JSON
+    console.log = console.warn = () => {};
+
     let connection = createConnection(ProposedFeatures.all);
     worker.run(config, project, function(elm: ElmApp) {
         let report: Report | null = null;

--- a/ts/server/language-server.ts
+++ b/ts/server/language-server.ts
@@ -70,9 +70,7 @@ function start(config: Config, info: Info, project: {}) {
             // When publishing diagnostics it looks like you have to publish
             // for one URI at a time, so this groups all of the messages for
             // each file and sends them as a batch
-            _.forEach(_.groupBy(report.messages, 'file'), (messages, file) => 
-                publishDiagnostics(messages, fileUrl(file))
-            );
+            _.forEach(_.groupBy(report.messages, 'file'), (messages, file) => publishDiagnostics(messages, fileUrl(file)));
         });
     });
 }
@@ -89,9 +87,7 @@ function messageToDiagnostic(message: Message): Diagnostic {
         // Clean up the error message a bit, removing the end of the line, e.g.
         // "Record has only one field. Use the field's type or introduce a Type. At ((14,5),(14,20))"
         message:
-            message.data.description.split(/at .+$/i)[0] +
-            '\n' +
-            `See https://stil4m.github.io/elm-analyse/#/messages/${message.type}`,
+            message.data.description.split(/at .+$/i)[0] + '\n' + `See https://stil4m.github.io/elm-analyse/#/messages/${message.type}`,
         source: 'elm-analyse'
     };
 }

--- a/ts/server/language-server.ts
+++ b/ts/server/language-server.ts
@@ -1,0 +1,115 @@
+import * as path from 'path';
+import { Config, Info, ElmApp, Report, Message } from '../domain';
+import _ from 'lodash';
+import worker from './worker';
+import watcher from './watcher';
+import {
+    createConnection,
+    TextDocuments,
+    TextDocument,
+    Diagnostic,
+    DiagnosticSeverity,
+    ProposedFeatures,
+    InitializeParams
+} from 'vscode-languageserver';
+
+function start(config: Config, info: Info, project: {}) {
+    let connection = createConnection(ProposedFeatures.all);
+    worker.run(config, project, function(elm: ElmApp) {
+        let report: Report | null = null;
+        let documents: TextDocuments = new TextDocuments();
+
+        watcher.run(elm);
+        documents.listen(connection);
+        connection.listen();
+
+        connection.onInitialize((params: InitializeParams) => ({
+            capabilities: {
+                textDocumentSync: {
+                    openClose: true,
+                    willSave: true
+                },
+                textDocument: {
+                    publishDiagnostics: {
+                        relatedInformation: true
+                    }
+                }
+            }
+        }));
+        // The content of a text document has changed. This event is emitted
+        // when the text document first opened or when its content has changed.
+        documents.onDidChangeContent(change => {
+            validateTextDocument(change.document);
+        });
+        documents.onDidSave(change => {
+            validateTextDocument(change.document);
+        });
+        function publishDiagnostics(messages: Message[], uri: string) {
+            const messagesForFile = messages.filter(m =>
+                // Windows paths have a forward slash in the `message.file`, which won't
+                // match with the end of the file URI we have from the language server event,
+                // so this replaces backslashes before matching to get consistent behavior
+                uri.endsWith(m.file.replace('\\', '/'))
+            );
+
+            let diagnostics: Diagnostic[] = messagesForFile.map(messageToDiagnostic);
+            connection.sendDiagnostics({ uri: uri, diagnostics });
+        }
+        async function waitForReport(): Promise<Report> {
+            return report ? Promise.resolve(report) : sleep(500).then(waitForReport);
+        }
+
+        async function validateTextDocument(textDocument: TextDocument): Promise<void> {
+            const report = await waitForReport();
+            publishDiagnostics(report.messages, textDocument.uri);
+        }
+
+        elm.ports.sendReportValue.subscribe(function(newReport) {
+            report = newReport;
+
+            // When publishing diagnostics it looks like you have to publish
+            // for one URI at a time, so this groups all of the messages for
+            // each file and sends them as a batch
+            _.forEach(_.groupBy(report.messages, 'file'), (messages, file) => 
+                publishDiagnostics(messages, fileUrl(file))
+            );
+        });
+    });
+}
+
+function messageToDiagnostic(message: Message): Diagnostic {
+    let [lineStart, colStart, lineEnd, colEnd] = message.data.properties.range;
+    const range = {
+        start: { line: lineStart - 1, character: colStart - 1 },
+        end: { line: lineEnd - 1, character: colEnd - 1 }
+    };
+    return {
+        severity: DiagnosticSeverity.Warning,
+        range: range,
+        // Clean up the error message a bit, removing the end of the line, e.g.
+        // "Record has only one field. Use the field's type or introduce a Type. At ((14,5),(14,20))"
+        message:
+            message.data.description.split(/at .+$/i)[0] +
+            '\n' +
+            `See https://stil4m.github.io/elm-analyse/#/messages/${message.type}`,
+        source: 'elm-analyse'
+    };
+}
+
+function fileUrl(str: string) {
+    if (typeof str !== 'string') {
+        throw new Error('Expected a string');
+    }
+    var pathName = path.resolve(str).replace(/\\/g, '/');
+    // Windows drive letter must be prefixed with a slash
+    if (pathName[0] !== '/') {
+        pathName = '/' + pathName;
+    }
+    return encodeURI('file://' + pathName);
+}
+
+async function sleep(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export default { start };


### PR DESCRIPTION
I love elm-analyse and I was motivated after a user, theotherben, posted a script on the #vim channel on elm slack that added [ALE](https://github.com/w0rp/ale) support by parsing the output of `elm-analyse`.

I used it for a while on our codebase at work, but it took a while to get results because it spawned a new `elm-analyse` process each time, so I started working on a server implementation that spawned `elm-analyse` processes, kept them alive, and communicated with them over http, but it also requires prompting for network permissions and I felt it would be nicer if that could be avoided, so I arrived at this.

It extends the CLI options so that you can start it in language server mode:
```
elm-analyse --lsp --stdio
```

It also supports `--node-ipc` and `--socket={number}` when you use the `--lsp` option, and at least one of them must be specified.

The vim plugin side of this is https://github.com/antew/vim-elm-analyse, I published a branch of `elm-analyse` with the compiled files as well to make trying it out easier:
```
npm i -g antew/elm-analyse#lsp
```
and then in vim
```
Plug 'antew/vim-elm-analyse'
```

- Lint results are published as diagnostic messages
- The server can be connected to via stdio, a socket, or node-ipc
- Lint results are published as files are opened and as they are saved,
it uses the cached Report to filter to messages for that file.
- Lint results are published as new reports are generated.
- Supports Windows and OSX (tested through Vim on Git for Windows Bash
and nvim on OSX)

Edit:
I wanted to see how portable the LSPs are so I implemented a VSCode version here https://github.com/antew/vscode-elm-analyse - most of it is boilerplate from the documentation, it took around 30 minutes to get it working.