### PR TITLE
Allow loading files with content for better integration with language servers

### DIFF
--- a/src/Analyser/FileWatch.elm
+++ b/src/Analyser/FileWatch.elm
@@ -1,5 +1,7 @@
 port module Analyser.FileWatch exposing (FileChange(..), watcher)
 
+import Analyser.Files.FileContent exposing (FileContent)
+
 
 port fileWatch : (RawFileChange -> msg) -> Sub msg
 
@@ -7,11 +9,12 @@ port fileWatch : (RawFileChange -> msg) -> Sub msg
 type alias RawFileChange =
     { event : String
     , file : String
+    , content : Maybe String
     }
 
 
 type FileChange
-    = Update String
+    = Update String (Maybe FileContent)
     | Remove String
 
 
@@ -20,11 +23,21 @@ watcher f =
     fileWatch (asFileChange >> f)
 
 
+asFileContent : RawFileChange -> String -> FileContent
+asFileContent p content =
+    { path = p.file
+    , success = True
+    , sha1 = Nothing
+    , content = Just content
+    , ast = Nothing
+    }
+
+
 asFileChange : RawFileChange -> Maybe FileChange
 asFileChange p =
     case p.event of
         "update" ->
-            Just <| Update p.file
+            Just <| Update p.file (Maybe.map (asFileContent p) p.content)
 
         "remove" ->
             Just <| Remove p.file

--- a/src/Analyser/Files/FileLoader.elm
+++ b/src/Analyser/Files/FileLoader.elm
@@ -1,4 +1,4 @@
-port module Analyser.Files.FileLoader exposing (Msg, init, subscriptions, update)
+port module Analyser.Files.FileLoader exposing (Msg, init, load, subscriptions, update)
 
 import Analyser.Files.FileContent as FileContent exposing (FileContent)
 import Analyser.Files.Types exposing (LoadedSourceFile)
@@ -44,23 +44,28 @@ update : Msg -> ( LoadedSourceFile, Cmd a )
 update msg =
     case msg of
         OnFileContent fc ->
-            let
-                ( fileLoad, store ) =
-                    FileContent.asRawFile fc
+            load fc
 
-                cmd : Cmd a
-                cmd =
-                    if store then
-                        fileLoad
-                            |> Result.toMaybe
-                            |> Maybe.map Elm.RawFile.encode
-                            |> Maybe.map2 AstStore fc.sha1
-                            |> Maybe.map storeAstForSha
-                            |> Maybe.withDefault Cmd.none
 
-                    else
-                        Cmd.none
-            in
-            ( ( fc, fileLoad )
-            , cmd
-            )
+load : FileContent -> ( LoadedSourceFile, Cmd a )
+load fc =
+    let
+        ( fileLoad, store ) =
+            FileContent.asRawFile fc
+
+        cmd : Cmd a
+        cmd =
+            if store then
+                fileLoad
+                    |> Result.toMaybe
+                    |> Maybe.map Elm.RawFile.encode
+                    |> Maybe.map2 AstStore fc.sha1
+                    |> Maybe.map storeAstForSha
+                    |> Maybe.withDefault Cmd.none
+
+            else
+                Cmd.none
+    in
+    ( ( fc, fileLoad )
+    , cmd
+    )

--- a/src/Analyser/SourceLoadingStage.elm
+++ b/src/Analyser/SourceLoadingStage.elm
@@ -1,5 +1,6 @@
-module Analyser.SourceLoadingStage exposing (Model, Msg, init, isDone, parsedFiles, subscriptions, update)
+module Analyser.SourceLoadingStage exposing (Model, Msg, init, initWithContent, isDone, parsedFiles, subscriptions, update)
 
+import Analyser.Files.FileContent as FileContent exposing (FileContent)
 import Analyser.Files.FileLoader as FileLoader
 import Analyser.Files.Types exposing (LoadedSourceFile, LoadedSourceFiles)
 import List.Extra
@@ -31,6 +32,21 @@ init input =
     , Cmd.none
     )
         |> loadNextFile
+
+
+initWithContent : FileContent -> ( Model, Cmd Msg )
+initWithContent input =
+    let
+        ( loadedSourceFile, cmds ) =
+            FileLoader.load input
+    in
+    ( Model
+        { filesToLoad = []
+        , loadingFiles = Set.empty
+        , parsedFiles = [ loadedSourceFile ]
+        }
+    , cmds
+    )
 
 
 isDone : Model -> Bool

--- a/src/Analyser/SourceLoadingStage.elm
+++ b/src/Analyser/SourceLoadingStage.elm
@@ -1,6 +1,6 @@
 module Analyser.SourceLoadingStage exposing (Model, Msg, init, initWithContent, isDone, parsedFiles, subscriptions, update)
 
-import Analyser.Files.FileContent as FileContent exposing (FileContent)
+import Analyser.Files.FileContent exposing (FileContent)
 import Analyser.Files.FileLoader as FileLoader
 import Analyser.Files.Types exposing (LoadedSourceFile, LoadedSourceFiles)
 import List.Extra

--- a/ts/domain.ts
+++ b/ts/domain.ts
@@ -152,7 +152,7 @@ interface FileRef {
 interface Message {
     id: number;
     status: string;
-    file: FileRef;
+    file: string;
     type: string;
     data: MessageData;
 }

--- a/ts/domain.ts
+++ b/ts/domain.ts
@@ -32,6 +32,7 @@ export interface DependencyFiles {
 export interface FileChange {
     event: string;
     file: string;
+    content: string | null;
 }
 export interface FileStore {
     file: string;

--- a/ts/file-loading-ports.ts
+++ b/ts/file-loading-ports.ts
@@ -5,7 +5,7 @@ import * as RawDependencies from './ports/raw-dependencies';
 import * as HttpDocumentation from './ports/http-documentation';
 import * as FileLoader from './ports/file-loader';
 import * as Context from './ports/context';
-import { LocalCache } from "./util/cache";
+import { LocalCache } from './util/cache';
 import { FileReader } from './fileReader';
 
 export function setup(app: ElmApp, config: Config, directory: string): void {

--- a/ts/file-loading-ports.ts
+++ b/ts/file-loading-ports.ts
@@ -6,7 +6,7 @@ import * as HttpDocumentation from './ports/http-documentation';
 import * as FileLoader from './ports/file-loader';
 import * as Context from './ports/context';
 import { LocalCache } from "./util/cache";
-import  { FileReader } from './fileReader';
+import { FileReader } from './fileReader';
 
 export function setup(app: ElmApp, config: Config, directory: string): void {
     const localCache = new LocalCache(directory);

--- a/ts/file-loading-ports.ts
+++ b/ts/file-loading-ports.ts
@@ -5,11 +5,16 @@ import * as RawDependencies from './ports/raw-dependencies';
 import * as HttpDocumentation from './ports/http-documentation';
 import * as FileLoader from './ports/file-loader';
 import * as Context from './ports/context';
+import { LocalCache } from "./util/cache";
+import  { FileReader } from './fileReader';
 
 export function setup(app: ElmApp, config: Config, directory: string): void {
+    const localCache = new LocalCache(directory);
+    const fileReader = new FileReader(localCache);
+
     HttpDocumentation.setup(app);
     RawDependencies.setup(app);
-    DependencyFiles.setup(app, directory);
-    FileLoader.setup(app, config, directory);
+    DependencyFiles.setup(app, directory, fileReader);
+    FileLoader.setup(app, config, directory, localCache, fileReader);
     Context.setup(app, directory);
 }

--- a/ts/fileReader.ts
+++ b/ts/fileReader.ts
@@ -1,8 +1,71 @@
 // Reference the module
 import * as fs from 'fs';
-import * as cache from './util/cache';
+import { LocalCache } from './util/cache';
 const sums = require('sums');
 import { FileContent } from './domain';
+
+export class FileReader {
+    private cache: LocalCache;
+
+    constructor(cache: LocalCache) {
+        this.cache = cache;
+        cache.setupShaFolder();
+    }
+
+    private readFileNotCached(
+        realPath: string,
+        path: string,
+        checksum: string
+    ) {
+        return new Promise((accept: (data: FileContent) => void) => {
+            fs.readFile(realPath, function(e, content) {
+                if (e) {
+                    accept(errorResponse(path));
+                    return;
+                }
+                const originalContent = content.toString();
+
+                accept({
+                    success: true,
+                    path: path,
+                    sha1: checksum,
+                    content: originalContent,
+                    ast: null
+                });
+            });
+        });
+    }
+
+    public readFile(
+        directory: string,
+        path: string,
+        cb: (data: FileContent) => void
+    ) {
+        var real = directory + '/' + path;
+
+        sums.checksum(fs.createReadStream(real))
+            .then(
+                (checkSumResult: { sum: string }) => {
+                    const checksum = checkSumResult.sum;
+
+                    if (this.cache.hasAstForSha(checksum)) {
+                        return {
+                            success: true,
+                            path: path,
+                            sha1: checksum,
+                            content: fs.readFileSync(real).toString(),
+                            ast: this.cache.readAstForSha(checksum)
+                        };
+                    }
+                    return this.readFileNotCached(real, path, checksum);
+                },
+                function() {
+                    return errorResponse(path);
+                }
+            )
+            .then(cb);
+    }
+}
 
 function errorResponse(path: string): FileContent {
     return {
@@ -13,54 +76,3 @@ function errorResponse(path: string): FileContent {
         ast: null
     };
 }
-
-function readFileNotCached(realPath: string, path: string, checksum: string) {
-    return new Promise((accept: (data: FileContent) => void) => {
-        fs.readFile(realPath, function(e, content) {
-            if (e) {
-                accept(errorResponse(path));
-                return;
-            }
-            const originalContent = content.toString();
-
-            accept({
-                success: true,
-                path: path,
-                sha1: checksum,
-                content: originalContent,
-                ast: null
-            });
-        });
-    });
-}
-
-function readFile(directory: string, path: string, cb: (data: FileContent) => void) {
-    var real = directory + '/' + path;
-
-    sums
-        .checksum(fs.createReadStream(real))
-        .then(
-            (checkSumResult: { sum: string }) => {
-                const checksum = checkSumResult.sum;
-
-                if (cache.hasAstForSha(checksum)) {
-                    return {
-                        success: true,
-                        path: path,
-                        sha1: checksum,
-                        content: fs.readFileSync(real).toString(),
-                        ast: cache.readAstForSha(checksum)
-                    };
-                }
-                return readFileNotCached(real, path, checksum);
-            },
-            function() {
-                return errorResponse(path);
-            }
-        )
-        .then(cb);
-}
-
-cache.setupShaFolder();
-
-export { readFile };

--- a/ts/fileReader.ts
+++ b/ts/fileReader.ts
@@ -12,11 +12,7 @@ export class FileReader {
         cache.setupShaFolder();
     }
 
-    private readFileNotCached(
-        realPath: string,
-        path: string,
-        checksum: string
-    ) {
+    private readFileNotCached(realPath: string, path: string, checksum: string) {
         return new Promise((accept: (data: FileContent) => void) => {
             fs.readFile(realPath, function(e, content) {
                 if (e) {
@@ -36,14 +32,11 @@ export class FileReader {
         });
     }
 
-    public readFile(
-        directory: string,
-        path: string,
-        cb: (data: FileContent) => void
-    ) {
+    public readFile(directory: string, path: string, cb: (data: FileContent) => void) {
         var real = directory + '/' + path;
 
-        sums.checksum(fs.createReadStream(real))
+        sums
+            .checksum(fs.createReadStream(real))
             .then(
                 (checkSumResult: { sum: string }) => {
                     const checksum = checkSumResult.sum;

--- a/ts/ports/dependency-files.ts
+++ b/ts/ports/dependency-files.ts
@@ -1,8 +1,8 @@
 import * as fileGatherer from '../util/file-gatherer';
 import { ElmApp, DependencyPointer, FileContent } from '../domain';
-import * as fileReader from '../fileReader';
+import { FileReader } from '../fileReader';
 
-function setup(app: ElmApp, directory: string) {
+function setup(app: ElmApp, directory: string, fileReader: FileReader) {
     app.ports.loadDependencyFiles.subscribe((dependency: DependencyPointer) => {
         const result = fileGatherer.getDependencyFiles(directory, dependency);
 

--- a/ts/ports/file-loader.ts
+++ b/ts/ports/file-loader.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs';
-import { LocalCache } from "../util/cache";
+import { LocalCache } from '../util/cache';
 import * as cp from 'child_process';
 import { ElmApp, FileStore, AstStore, Config, FileContent, FileContentSha } from '../domain';
-import  { FileReader } from '../fileReader';
+import { FileReader } from '../fileReader';
 
 function setup(app: ElmApp, config: Config, directory: string, cache: LocalCache, fileReader: FileReader) {
     app.ports.loadFile.subscribe(fileName => {

--- a/ts/ports/file-loader.ts
+++ b/ts/ports/file-loader.ts
@@ -1,10 +1,10 @@
 import * as fs from 'fs';
-import * as cache from '../util/cache';
+import { LocalCache } from "../util/cache";
 import * as cp from 'child_process';
 import { ElmApp, FileStore, AstStore, Config, FileContent, FileContentSha } from '../domain';
-import * as fileReader from '../fileReader';
+import  { FileReader } from '../fileReader';
 
-function setup(app: ElmApp, config: Config, directory: string) {
+function setup(app: ElmApp, config: Config, directory: string, cache: LocalCache, fileReader: FileReader) {
     app.ports.loadFile.subscribe(fileName => {
         fileReader.readFile(directory, fileName, result => app.ports.fileContent.send(result));
     });

--- a/ts/server/watcher.ts
+++ b/ts/server/watcher.ts
@@ -5,7 +5,7 @@ import { ElmApp, FileChange } from '../domain';
 function run(elmWorker: ElmApp) {
     const pack = require(process.cwd() + '/elm.json');
     watch(pack['source-directories'] || ['src'], { recursive: true }, function(evt: string, name: string) {
-        const change: FileChange = { event: evt, file: name };
+        const change: FileChange = { event: evt, file: name, content: null };
         if (fileGatherer.includedInFileSet(name)) {
             elmWorker.ports.fileWatch.send(change);
         }

--- a/ts/util/cache.ts
+++ b/ts/util/cache.ts
@@ -4,10 +4,39 @@ import * as fsExtra from 'fs-extra';
 // const fsExtra = require('fs-extra');
 const osHomedir = require('os-homedir');
 import * as path from 'path';
-const cachePath = path.resolve('elm-stuff', '.elm-analyse');
 const packageJsonPath = path.resolve(__dirname, '..', '..', '..', 'package.json');
 const elmAnalyseVersion = require(packageJsonPath).version;
 
+class LocalCache {
+    private cachePath: string;
+    constructor(projectPath: string) {
+        this.cachePath = path.join(projectPath, 'elm-stuff', '.elm-analyse');
+    }
+    public storeShaJson(sha1: string, content: JSON) {
+        fs.writeFile(
+            path.resolve(this.cachePath, '_shas', sha1 + '.json'),
+            JSON.stringify(content),
+            function() {}
+        );
+    }
+    public elmCachePathForSha(sha: string) {
+        return path.resolve(this.cachePath, '_shas', sha + '.elma');
+    }
+
+    public astCachePathForSha(sha: string): string {
+        return path.resolve(this.cachePath, '_shas', sha + '.json');
+    }
+    public setupShaFolder(): void {
+        fsExtra.ensureDirSync(path.resolve(this.cachePath, '_shas'));
+    }
+    public hasAstForSha(sha: string): boolean {
+        return fs.existsSync(this.astCachePathForSha(sha));
+    }
+
+    public readAstForSha(sha: string): string {
+        return fs.readFileSync(this.astCachePathForSha(sha)).toString();
+    }
+}
 var major: string;
 if (elmAnalyseVersion.split('.')[0] === '0') {
     major = '0.' + elmAnalyseVersion.split('.')[1];
@@ -56,34 +85,10 @@ function storeDependencyJson(dependency: string, version: string, content: strin
     fs.writeFile(targetPath, content, function() {});
 }
 
-function elmCachePathForSha(sha: string) {
-    return path.resolve(cachePath, '_shas', sha + '.elma');
-}
-
-function astCachePathForSha(sha: string): string {
-    return path.resolve(cachePath, '_shas', sha + '.json');
-}
-
-function hasAstForSha(sha: string): boolean {
-    return fs.existsSync(astCachePathForSha(sha));
-}
-
-function readAstForSha(sha: string): string {
-    return fs.readFileSync(astCachePathForSha(sha)).toString();
-}
-
-function setupShaFolder(): void {
-    fsExtra.ensureDirSync(path.resolve(cachePath, '_shas'));
-}
-
 export {
-    storeShaJson,
     readDependencyJson,
     readPackageDependencyInfo,
     storePackageDependencyInfo,
     storeDependencyJson,
-    hasAstForSha,
-    elmCachePathForSha,
-    readAstForSha,
-    setupShaFolder
+    LocalCache
 };

--- a/ts/util/cache.ts
+++ b/ts/util/cache.ts
@@ -37,7 +37,7 @@ function readPackageDependencyInfo(cb: ((err: any, result: any) => void)) {
 function storePackageDependencyInfo(data: any) {
     fs.writeFile(path.resolve(globalCachePath, 'all-packages.json'), JSON.stringify(data), function() {});
 }
-function readDependencyJson(dependency: string, version: string, cb: (err: NodeJS.ErrnoException, data: Buffer) => void) {
+function readDependencyJson(dependency: string, version: string, cb: (err: NodeJS.ErrnoException | null, data: Buffer) => void) {
     //TODO Error handling
 
     fs.readFile(path.resolve(globalCachePath, 'interfaces', dependency, version, 'dependency.json'), cb);

--- a/ts/util/cache.ts
+++ b/ts/util/cache.ts
@@ -72,10 +72,6 @@ function readDependencyJson(dependency: string, version: string, cb: (err: NodeJ
     fs.readFile(path.resolve(globalCachePath, 'interfaces', dependency, version, 'dependency.json'), cb);
 }
 
-function storeShaJson(sha1: string, content: JSON) {
-    fs.writeFile(path.resolve(cachePath, '_shas', sha1 + '.json'), JSON.stringify(content), function() {});
-}
-
 function storeDependencyJson(dependency: string, version: string, content: string) {
     const targetDir = path.resolve(globalCachePath, 'interfaces', dependency, version);
     const targetPath = path.resolve(targetDir, 'dependency.json');

--- a/ts/util/cache.ts
+++ b/ts/util/cache.ts
@@ -13,11 +13,7 @@ class LocalCache {
         this.cachePath = path.join(projectPath, 'elm-stuff', '.elm-analyse');
     }
     public storeShaJson(sha1: string, content: JSON) {
-        fs.writeFile(
-            path.resolve(this.cachePath, '_shas', sha1 + '.json'),
-            JSON.stringify(content),
-            function() {}
-        );
+        fs.writeFile(path.resolve(this.cachePath, '_shas', sha1 + '.json'), JSON.stringify(content), function() {});
     }
     public elmCachePathForSha(sha: string) {
         return path.resolve(this.cachePath, '_shas', sha + '.elma');
@@ -81,10 +77,4 @@ function storeDependencyJson(dependency: string, version: string, content: strin
     fs.writeFile(targetPath, content, function() {});
 }
 
-export {
-    readDependencyJson,
-    readPackageDependencyInfo,
-    storePackageDependencyInfo,
-    storeDependencyJson,
-    LocalCache
-};
+export { readDependencyJson, readPackageDependencyInfo, storePackageDependencyInfo, storeDependencyJson, LocalCache };


### PR DESCRIPTION
A while back I opened #188, but I closed it because I thought that language server integration would be better if it was decoupled from elm-analyse itself, so I pared this down to only the features that really helped in integrating it, they are:
- Allowing you to update file contents in elm-analyse without needing them written to disk.
- Allowing file loading ports to accept file content along with the file path if available.
- Reparsing on the fly as the contents are updated

I've been using it for a while through Vim, and it is fast enough to leave on insert mode and have it lint as I type.

Misc Fixes:
- tsc was complaining about the return type in ts/util/cache.js