### PR TITLE
Read elm-analyse.json from same directory as elm.json

### DIFF
--- a/ts/ports/context.ts
+++ b/ts/ports/context.ts
@@ -1,13 +1,14 @@
 import * as fs from 'fs';
 import * as fileGatherer from '../util/file-gatherer';
 import { ElmApp, Context } from '../domain';
+import * as path from 'path';
 
 function setup(app: ElmApp, directory: string) {
     app.ports.loadContext.subscribe(() => {
         const input = fileGatherer.gather(directory);
         var configuration;
         try {
-            configuration = fs.readFileSync('./elm-analyse.json').toString();
+            configuration = fs.readFileSync(path.join(directory, 'elm-analyse.json')).toString();
         } catch (e) {
             configuration = '';
         }


### PR DESCRIPTION
This came up with multi-project structures where you may open "/project/" in an editor and have an elm project under "/project/web/", it currently uses the working directory to look up `elm.json` so it ends up looking for `/project/elm-analyse.json` rather than `/project/web/elm-analyse.json`