### PR TITLE
Align analyse message format

### DIFF
--- a/src/Analyser/Checks/TriggerWords.elm
+++ b/src/Analyser/Checks/TriggerWords.elm
@@ -49,7 +49,7 @@ buildMessage : ( String, Range ) -> MessageData
 buildMessage ( word, range ) =
     Data.init
         (String.concat
-            [ "`" ++ word ++ "` should not be used in comments. Found at "
+            [ "`" ++ word ++ "` should not be used in comments at "
             , Range.rangeToString range
             ]
         )


### PR DESCRIPTION
As all other messages use the " at ((0,10)(0,20))" format at the end of the line it would be nice to keep this consistent.

At the moment we're removing these from the log messages via a split, as we need the message and the location to be separate. And having the location in the message doesn't add any value.