### PR TITLE
LSP helpers - Allow sending fixed file content back without writing to disk

### DIFF
--- a/src/Analyser.elm
+++ b/src/Analyser.elm
@@ -8,7 +8,6 @@ import Analyser.FileContext as FileContext exposing (FileContext)
 import Analyser.FileWatch as FileWatch exposing (FileChange(..))
 import Analyser.Files.Types exposing (LoadedSourceFile)
 import Analyser.Fixer as Fixer
-import Analyser.Messages.Types exposing (Message)
 import Analyser.Messages.Util as Messages
 import Analyser.Modules
 import Analyser.SourceLoadingStage as SourceLoadingStage

--- a/src/Analyser/CodeBase.elm
+++ b/src/Analyser/CodeBase.elm
@@ -4,7 +4,6 @@ import Analyser.Files.Types exposing (LoadedSourceFile)
 import Dict exposing (Dict)
 import Elm.Dependency exposing (Dependency)
 import Elm.Processing as Processing exposing (ProcessContext)
-import Elm.Syntax.File exposing (File)
 
 
 type CodeBase

--- a/src/Analyser/CodeBase.elm
+++ b/src/Analyser/CodeBase.elm
@@ -1,9 +1,10 @@
-module Analyser.CodeBase exposing (CodeBase, addSourceFiles, dependencies, init, mergeLoadedSourceFiles, processContext, setDependencies, sourceFiles)
+module Analyser.CodeBase exposing (CodeBase, addSourceFiles, dependencies, getFile, init, mergeLoadedSourceFiles, processContext, setDependencies, sourceFiles)
 
 import Analyser.Files.Types exposing (LoadedSourceFile)
 import Dict exposing (Dict)
 import Elm.Dependency exposing (Dependency)
 import Elm.Processing as Processing exposing (ProcessContext)
+import Elm.Syntax.File exposing (File)
 
 
 type CodeBase
@@ -62,3 +63,8 @@ addSourceFiles sources (CodeBase codeBase) =
 mergeLoadedSourceFiles : List LoadedSourceFile -> Dict String LoadedSourceFile -> Dict String LoadedSourceFile
 mergeLoadedSourceFiles newItems dict =
     List.foldl (\sourceFile -> Dict.insert (Tuple.first sourceFile).path sourceFile) dict newItems
+
+
+getFile : String -> CodeBase -> Maybe LoadedSourceFile
+getFile path (CodeBase codeBase) =
+    Dict.get path codeBase.sources

--- a/src/Analyser/FileContext.elm
+++ b/src/Analyser/FileContext.elm
@@ -1,4 +1,4 @@
-module Analyser.FileContext exposing (FileContext, build, moduleName)
+module Analyser.FileContext exposing (FileContext, build, buildForFile, moduleName)
 
 import Analyser.CodeBase as CodeBase exposing (CodeBase)
 import Analyser.FileRef exposing (FileRef)

--- a/src/Analyser/Fixer.elm
+++ b/src/Analyser/Fixer.elm
@@ -1,6 +1,7 @@
-port module Analyser.Fixer exposing (Model, Msg, fixFast, init, initWithMessage, isDone, message, subscriptions, succeeded, update)
+port module Analyser.Fixer exposing (Model, Msg, getFixedFile, init, initWithMessage, isDone, message, subscriptions, succeeded, update)
 
 import Analyser.CodeBase as CodeBase exposing (CodeBase)
+import Analyser.FileContext exposing (FileContext)
 import Analyser.FileRef exposing (FileRef)
 import Analyser.Fixers
 import Analyser.Fixes.Base exposing (Fixer, Patch(..))
@@ -71,12 +72,12 @@ initWithMessage mess state =
             )
 
 
-fixFast : Message -> ( String, File ) -> Result String String
-fixFast mess pathAndFile =
+getFixedFile : Message -> FileContext -> Result String String
+getFixedFile mess fileContext =
     Analyser.Fixers.getFixer mess
         |> Maybe.map
             (\fixer ->
-                case fixer.fix pathAndFile mess.data of
+                case fixer.fix ( fileContext.content, fileContext.ast ) mess.data of
                     Error e ->
                         Err e
 

--- a/src/Analyser/Fixer.elm
+++ b/src/Analyser/Fixer.elm
@@ -1,4 +1,4 @@
-port module Analyser.Fixer exposing (Model, Msg, init, initWithMessage, isDone, message, subscriptions, succeeded, update)
+port module Analyser.Fixer exposing (Model, Msg, fixFast, init, initWithMessage, isDone, message, subscriptions, succeeded, update)
 
 import Analyser.CodeBase as CodeBase exposing (CodeBase)
 import Analyser.FileRef exposing (FileRef)
@@ -69,6 +69,24 @@ initWithMessage mess state =
                 , State.startFixing mess state
                 )
             )
+
+
+fixFast : Message -> ( String, File ) -> Result String String
+fixFast mess pathAndFile =
+    Analyser.Fixers.getFixer mess
+        |> Maybe.map
+            (\fixer ->
+                case fixer.fix pathAndFile mess.data of
+                    Error e ->
+                        Err e
+
+                    Patched p ->
+                        Ok p
+
+                    IncompatibleData ->
+                        Err ("Invalid message data for fixer, message id: " ++ String.fromInt mess.id)
+            )
+        |> Maybe.withDefault (Err "Unable to find fixer")
 
 
 isDone : Model -> Bool

--- a/src/AnalyserPorts.elm
+++ b/src/AnalyserPorts.elm
@@ -1,4 +1,4 @@
-port module AnalyserPorts exposing (onFixMessage, onReset, sendReport, sendStateValue)
+port module AnalyserPorts exposing (onFixMessage, onFixQuick, onReset, sendFixedFile, sendReport, sendStateValue)
 
 import Analyser.Report as Report exposing (Report)
 import Analyser.State exposing (State, encodeState)
@@ -11,10 +11,16 @@ port sendReportValue : Value -> Cmd msg
 port sendState : Value -> Cmd msg
 
 
+port sendFixedFile : { path : String, content : String } -> Cmd msg
+
+
 port onReset : (Bool -> msg) -> Sub msg
 
 
 port onFixMessage : (Int -> msg) -> Sub msg
+
+
+port onFixQuick : (Int -> msg) -> Sub msg
 
 
 sendReport : Report -> Cmd msg

--- a/ts/domain.ts
+++ b/ts/domain.ts
@@ -43,8 +43,8 @@ export interface AstStore {
     ast: JSON;
 }
 export interface FixedFile {
-    path : string,
-    content: string
+    path: string;
+    content: string;
 }
 
 export interface LogMessage {
@@ -105,8 +105,8 @@ interface EditorElmApp {
 }
 
 interface Subscription<T> {
-    subscribe: ((cb: ((d: T) => void)) => void);
-    unsubscribe: ((cb: ((d: T) => void)) => void);
+    subscribe: (cb: (d: T) => void) => void;
+    unsubscribe: (cb: (d: T) => void) => void;
 }
 
 interface FileContentSha {
@@ -123,7 +123,7 @@ interface Context {
     configuration: string;
 }
 interface MailBox<T> {
-    send: ((d: T) => void);
+    send: (d: T) => void;
 }
 
 interface Reporter {

--- a/ts/domain.ts
+++ b/ts/domain.ts
@@ -42,6 +42,10 @@ export interface AstStore {
     sha1: string;
     ast: JSON;
 }
+export interface FixedFile {
+    path : string,
+    content: string
+}
 
 export interface LogMessage {
     level: string;
@@ -52,6 +56,7 @@ interface ElmApp {
         log: Subscription<LogMessage>;
         sendReportValue: Subscription<Report>;
         sendState: Subscription<State>;
+        sendFixedFile: Subscription<FixedFile>;
         loadContext: Subscription<void>;
         loadDependencyFiles: Subscription<DependencyPointer>;
         loadFile: Subscription<string>;
@@ -65,6 +70,7 @@ interface ElmApp {
         fileWatch: MailBox<FileChange>;
         onReset: MailBox<boolean>;
         onFixMessage: MailBox<number>;
+        onFixQuick: MailBox<number>;
         onLoadedContext: MailBox<Context>;
         onDependencyFiles: MailBox<DependencyFiles>;
         fileContent: MailBox<FileContent>;

--- a/ts/domain.ts
+++ b/ts/domain.ts
@@ -106,6 +106,7 @@ interface EditorElmApp {
 
 interface Subscription<T> {
     subscribe: ((cb: ((d: T) => void)) => void);
+    unsubscribe: ((cb: ((d: T) => void)) => void);
 }
 
 interface FileContentSha {


### PR DESCRIPTION
Thank you for writing elm-analyse, and for making the codebase nice to work with!

This came up in supporting code actions from an editor, the language server receives a request that an issue needs to be fixed and is expected to return a list of replacement text for the text ranges. The existing setup writes the file to disk which wouldn't allow the language server itself to request the change.

Please let me know if you see anything that could be done in a better way or if you have any other requests!

One spot for future optimization would be to allow `elm-analyse` to return the list of edits rather than the new file content, the `FileContent.*` methods are pretty much there, but it seemed a bit daunting to add functions for edit lists for all of them in the first PR for it. What we're doing now is diffing the old file and the fixed file in the language server and generating the edit list there.

![fixer](https://user-images.githubusercontent.com/1693421/59164627-65b0c580-8add-11e9-9265-b8b462607364.gif)
