### PR TITLE
check for if-blocks with boolean literals for both branches

### DIFF
--- a/src/ASTUtil/Functions.elm
+++ b/src/ASTUtil/Functions.elm
@@ -15,11 +15,9 @@ isStatic function =
     if List.length decl.arguments > 0 then
         False
 
-    else if Maybe.withDefault False <| Maybe.map (Node.value >> isFunctionSignature) function.signature then
-        False
-
     else
-        True
+        Maybe.withDefault True <|
+            Maybe.map (Node.value >> isFunctionSignature >> not) function.signature
 
 
 isFunctionSignature : Signature -> Bool

--- a/src/Analyser/Checks.elm
+++ b/src/Analyser/Checks.elm
@@ -19,6 +19,7 @@ import Analyser.Checks.NoUncurriedPrefix as NoUncurriedPrefix
 import Analyser.Checks.SingleFieldRecord as SingleFieldRecord
 import Analyser.Checks.TriggerWords as TriggerWords
 import Analyser.Checks.UnnecessaryListConcat as UnnecessaryListConcat
+import Analyser.Checks.UnnecessaryLiteralBools as UnnecessaryLiteralBools
 import Analyser.Checks.UnnecessaryParens as UnnecessaryParens
 import Analyser.Checks.UnnecessaryPortModule as UnnecessaryPortModule
 import Analyser.Checks.UnusedImport as UnusedImport
@@ -68,4 +69,5 @@ all =
     , TriggerWords.checker
     , BooleanCase.checker
     , MapNothingToNothing.checker
+    , UnnecessaryLiteralBools.checker
     ]

--- a/src/Analyser/Checks/DebugCrash.elm
+++ b/src/Analyser/Checks/DebugCrash.elm
@@ -66,11 +66,7 @@ onExpression (Node range expression) context =
 entryForQualifiedExpr : List String -> String -> Bool
 entryForQualifiedExpr moduleName f =
     if moduleName == [ "Debug" ] then
-        if f == "todo" then
-            True
-
-        else
-            False
+        f == "todo"
 
     else
         False

--- a/src/Analyser/Checks/DebugLog.elm
+++ b/src/Analyser/Checks/DebugLog.elm
@@ -62,11 +62,7 @@ onExpression (Node range expression) context =
 entryForQualifiedExpr : List String -> String -> Bool
 entryForQualifiedExpr moduleName f =
     if moduleName == [ "Debug" ] then
-        if f == "log" then
-            True
-
-        else
-            False
+        f == "log"
 
     else
         False

--- a/src/Analyser/Checks/UnnecessaryLiteralBools.elm
+++ b/src/Analyser/Checks/UnnecessaryLiteralBools.elm
@@ -1,0 +1,77 @@
+module Analyser.Checks.UnnecessaryLiteralBools exposing (checker)
+
+import AST.Ranges as Range
+import ASTUtil.Inspector as Inspector exposing (Order(..), defaultConfig)
+import Analyser.Checks.Base exposing (Checker)
+import Analyser.Configuration exposing (Configuration)
+import Analyser.FileContext exposing (FileContext)
+import Analyser.Messages.Data as Data exposing (MessageData)
+import Analyser.Messages.Schema as Schema
+import Elm.Syntax.Expression exposing (Case, Expression(..))
+import Elm.Syntax.Node exposing (Node(..))
+import Elm.Syntax.Pattern exposing (Pattern(..))
+
+
+checker : Checker
+checker =
+    { check = scan
+    , info =
+        { key = "UnnecessaryLiteralBools"
+        , name = "Unnecessary Literal Booleans"
+        , description = "Directly use the boolean you already have."
+        , schema =
+            Schema.schema
+                |> Schema.rangeProp "range"
+        }
+    }
+
+
+type alias Context =
+    List MessageData
+
+
+scan : FileContext -> Configuration -> List MessageData
+scan fileContext _ =
+    Inspector.inspect
+        { defaultConfig
+            | onExpression = Post onExpression
+        }
+        fileContext.ast
+        []
+
+
+onExpression : Node Expression -> Context -> Context
+onExpression (Node r inner) context =
+    let
+        withMsg msg =
+            (Data.init
+                (String.concat
+                    [ msg
+                    , " "
+                    , Range.rangeToString r
+                    ]
+                )
+                |> Data.addRange "range" r
+            )
+                :: context
+    in
+    case inner of
+        IfBlock (Node _ _) (Node _ (FunctionOrValue _ trueVal)) (Node _ (FunctionOrValue _ falseVal)) ->
+            case ( trueVal, falseVal ) of
+                ( "True", "True" ) ->
+                    withMsg "Replace if-block with True"
+
+                ( "True", "False" ) ->
+                    withMsg "Replace if-block with just the if-condition"
+
+                ( "False", "True" ) ->
+                    withMsg "Replace if-block with just the negation of the if-condition"
+
+                ( "False", "False" ) ->
+                    withMsg "Replace if-block with False"
+
+                _ ->
+                    context
+
+        _ ->
+            context

--- a/src/Analyser/Checks/UnnecessaryLiteralBools.elm
+++ b/src/Analyser/Checks/UnnecessaryLiteralBools.elm
@@ -7,7 +7,7 @@ import Analyser.Configuration exposing (Configuration)
 import Analyser.FileContext exposing (FileContext)
 import Analyser.Messages.Data as Data exposing (MessageData)
 import Analyser.Messages.Schema as Schema
-import Elm.Syntax.Expression exposing (Case, Expression(..))
+import Elm.Syntax.Expression exposing (Expression(..))
 import Elm.Syntax.Node exposing (Node(..))
 import Elm.Syntax.Pattern exposing (Pattern(..))
 

--- a/tests/Analyser/Checks/UnnecessaryLiteralBoolsTests.elm
+++ b/tests/Analyser/Checks/UnnecessaryLiteralBoolsTests.elm
@@ -1,0 +1,34 @@
+module Analyser.Checks.UnnecessaryLiteralBoolsTests exposing (all)
+
+import Analyser.Checks.CheckTestUtil as CTU
+import Analyser.Checks.UnnecessaryLiteralBools as UnnecessaryLiteralBools
+import Analyser.Messages.Data as Data exposing (MessageData)
+import Test exposing (Test, only)
+
+
+redundantBoolean : ( String, String, List MessageData )
+redundantBoolean =
+    ( "redundantBoolean"
+    , """module Bar exposing (..)
+
+foo x =
+    if condition then
+        True
+
+    else
+        False
+
+"""
+    , [ Data.init "foo"
+            |> Data.addRange "range"
+                { start = { row = 4, column = 5 }, end = { row = 9, column = 1 } }
+      ]
+    )
+
+
+all : Test
+all =
+    CTU.build "Analyser.Checks.UnnecessaryLiteralBools"
+        UnnecessaryLiteralBools.checker
+        [ redundantBoolean
+        ]


### PR DESCRIPTION
hey! i saw #200 and wanted to get more familiar with this repo.

here, we check for situations where both branches of an `if` are a boolean literal e.g.

```elm
if <condition> then
    True

else
    False
```

i attempted to find unnecessary comparisons like `if <condition> == True`, but i couldn't figure out the pattern match. it also made me wonder if we should look for `if <condition> == True` or more generally just `<condition> == True` in all expressions, since such a comparison is unnecessary regardless of the `if` context.

potentially, that's a separate check or maybe this check should be expanded to address it. regardless, i was looking at this last night, but i wanted to get some feedback before proceeding. thanks!