### PR TITLE
Add handling of different log levels for messages from Elm

### DIFF
--- a/ts/bin/index.ts
+++ b/ts/bin/index.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import Server from '../server/app';
 import Analyser from '../analyser';
+import { LogLevel } from '../domain';
 
 var args = minimist(process.argv.slice(2), {
     alias: {
@@ -29,7 +30,8 @@ var args = minimist(process.argv.slice(2), {
         port: args.port || 3000,
         elmFormatPath: elmFormatPath,
         format: validFormats.indexOf(args.format) != -1 ? args.format : 'human',
-        open: args.open || false
+        open: args.open || false,
+        logLevel: LogLevel.INFO
     };
     const info = {
         version: elmAnalyseVersion,

--- a/ts/bin/index.ts
+++ b/ts/bin/index.ts
@@ -13,9 +13,10 @@ var args = minimist(process.argv.slice(2), {
         help: 'h',
         port: 'p',
         version: 'v',
-        open: 'o'
+        open: 'o',
+        quiet: 'q',
     },
-    boolean: ['serve', 'help', 'version', 'open'],
+    boolean: ['serve', 'help', 'version', 'open', 'quiet'],
     string: ['port', 'elm-format-path', 'format']
 });
 
@@ -31,7 +32,7 @@ var args = minimist(process.argv.slice(2), {
         elmFormatPath: elmFormatPath,
         format: validFormats.indexOf(args.format) != -1 ? args.format : 'human',
         open: args.open || false,
-        logLevel: LogLevel.INFO
+        logLevel: args.quiet ? LogLevel.ERROR : LogLevel.INFO
     };
     const info = {
         version: elmAnalyseVersion,
@@ -52,6 +53,7 @@ var args = minimist(process.argv.slice(2), {
         console.log('   --serve, -s         Enable server mode. Disabled by default.');
         console.log('   --port, -p          The port on which the server should listen. Defaults to 3000.');
         console.log('   --open, -o          Open default browser when server goes live.');
+        console.log('   --quiet, -q         Print fewer log messages.');
         console.log('   --elm-format-path   Path to elm-format. Defaults to `elm-format`.');
         console.log('   --format            Output format for CLI. Defaults to "human". Options "human"|"json"');
         process.exit(1);

--- a/ts/domain.ts
+++ b/ts/domain.ts
@@ -1,11 +1,19 @@
 interface Info {
     config: Config;
 }
+
+enum LogLevel {
+    INFO,
+    WARN,
+    ERROR,
+}
+
 interface Config {
     format: string | undefined;
     open: boolean;
     port: number;
     elmFormatPath: string;
+    logLevel: LogLevel;
 }
 
 export interface DependencyPointer {
@@ -48,7 +56,7 @@ export interface FixedFile {
 }
 
 export interface LogMessage {
-    level: string;
+    level: keyof typeof LogLevel;
     message: string;
 }
 interface ElmApp {
@@ -182,5 +190,6 @@ export {
     FileContentSha,
     EditorElmApp,
     EditorMessage,
-    EditorData
+    EditorData,
+    LogLevel
 };

--- a/ts/util/logging-ports.ts
+++ b/ts/util/logging-ports.ts
@@ -1,9 +1,11 @@
-import { Config, ElmApp, LogMessage } from '../domain';
+import { Config, ElmApp, LogLevel, LogMessage } from '../domain';
 
 export function setup(app: ElmApp, config: Config) {
     if (config.format === 'human') {
         app.ports.log.subscribe((data: LogMessage) => {
-            console.log(data.level + ':', data.message);
+            if (LogLevel[data.level] >= config.logLevel) {
+                console.log(data.level + ':', data.message);
+            }
         });
     }
 }


### PR DESCRIPTION
This PR adds filtering for which Elm log messages actually get to the console, as well as a CLI option (`-q`) to control the verbosity level. Though there are three log levels, I kept it to just a binary toggle to keep things simple; I'm happy to take suggestions on that or anything else.

Closes #216, more or less (this does nothing for TS-generated messages, but my main issue, at least, was the many `INFO: Load file ...` lines, which can now be suppressed).