### PR TITLE
Allow fixing a while file or project

### DIFF
--- a/src/Analyser.elm
+++ b/src/Analyser.elm
@@ -4,12 +4,13 @@ import Analyser.CodeBase as CodeBase exposing (CodeBase)
 import Analyser.Configuration as Configuration exposing (Configuration)
 import Analyser.ContextLoader as ContextLoader exposing (Context)
 import Analyser.DependencyLoadingStage as DependencyLoadingStage
-import Analyser.FileContext as FileContext exposing (FileContext)
 import Analyser.FileWatch as FileWatch exposing (FileChange(..))
 import Analyser.Files.Types exposing (LoadedSourceFile)
 import Analyser.Fixer as Fixer
+import Analyser.Fixers as Fixers
 import Analyser.Messages.Util as Messages
 import Analyser.Modules
+import Analyser.QuickFixer as QuickFixer
 import Analyser.SourceLoadingStage as SourceLoadingStage
 import Analyser.State as State exposing (State)
 import Analyser.State.Dependencies as Dependencies
@@ -19,7 +20,6 @@ import Elm.Version
 import Inspection
 import Json.Decode
 import Json.Encode exposing (Value)
-import Maybe.Extra as Maybe
 import Platform exposing (worker)
 import Registry exposing (Registry)
 import Time
@@ -47,7 +47,9 @@ type Msg
     | ReloadTick
     | Reset
     | OnFixMessage Int
+    | OnFixFileMessage String
     | OnQuickFixMessage Int
+    | OnQuickFixFileMessage String
     | FixerMsg Fixer.Msg
 
 
@@ -144,22 +146,35 @@ update msg model =
             )
                 |> handleNextStep
 
-        OnQuickFixMessage messageId ->
+        OnFixFileMessage path ->
             let
-                applyFix message =
-                    getFileContext message.file.path model.codeBase
-                        |> Maybe.map (Fixer.getFixedFile message)
-                        |> Maybe.withDefault
-                            (Err ("Unable to fix messageId: " ++ String.fromInt messageId))
+                messagesForFile =
+                    State.getMessagesForFile path model.state
+                        |> List.filter (\m -> Fixers.getFixer m /= Nothing)
             in
+            case QuickFixer.fixAll model.configuration model.codeBase messagesForFile path of
+                Ok fixedFile ->
+                    ( model
+                    , Fixer.storeFile
+                        { file = path
+                        , newContent = fixedFile
+                        }
+                    )
+
+                Err err ->
+                    ( model
+                    , Logger.info ("Unable to fix file: " ++ path ++ ", Err: " ++ err)
+                    )
+
+        OnQuickFixMessage messageId ->
             case State.getMessage messageId model.state of
                 Just message ->
-                    case applyFix message of
+                    case QuickFixer.fix model.codeBase message of
                         Ok fixedFile ->
                             ( model
                             , AnalyserPorts.sendFixedFile
                                 { path = message.file.path
-                                , content = fixedFile
+                                , content = fixedFile.content
                                 }
                             )
 
@@ -174,6 +189,26 @@ update msg model =
                         ("Unable to apply fix, unable to find messageId: "
                             ++ String.fromInt messageId
                         )
+                    )
+
+        OnQuickFixFileMessage path ->
+            let
+                messagesForFile =
+                    State.getMessagesForFile path model.state
+                        |> List.filter (\m -> Fixers.getFixer m /= Nothing)
+            in
+            case QuickFixer.fixAll model.configuration model.codeBase messagesForFile path of
+                Ok fixedFile ->
+                    ( model
+                    , AnalyserPorts.sendFixedFile
+                        { path = path
+                        , content = fixedFile
+                        }
+                    )
+
+                Err err ->
+                    ( model
+                    , Logger.info ("Unable to fix file: " ++ path ++ ", Err: " ++ err)
                     )
 
         Reset ->
@@ -443,14 +478,6 @@ onSourceLoadingStageMsg x stage model =
         )
 
 
-getFileContext : String -> CodeBase -> Maybe FileContext
-getFileContext path codeBase =
-    CodeBase.getFile path codeBase
-        |> Maybe.map
-            (FileContext.buildForFile (CodeBase.processContext codeBase))
-        |> Maybe.join
-
-
 subscriptions : Model -> Sub Msg
 subscriptions model =
     Sub.batch
@@ -462,7 +489,9 @@ subscriptions model =
             Sub.none
         , FileWatch.watcher Change
         , AnalyserPorts.onFixMessage OnFixMessage
+        , AnalyserPorts.onFixFileMessage OnFixFileMessage
         , AnalyserPorts.onFixQuick OnQuickFixMessage
+        , AnalyserPorts.onFixFileQuick OnQuickFixFileMessage
         , case model.stage of
             ContextLoadingStage ->
                 ContextLoader.onLoadedContext OnContext

--- a/src/Analyser/Fixer.elm
+++ b/src/Analyser/Fixer.elm
@@ -1,7 +1,6 @@
-port module Analyser.Fixer exposing (Model, Msg, getFixedFile, init, initWithMessage, isDone, message, subscriptions, succeeded, update)
+port module Analyser.Fixer exposing (Model, Msg, init, initWithMessage, isDone, message, storeFile, subscriptions, succeeded, update)
 
 import Analyser.CodeBase as CodeBase exposing (CodeBase)
-import Analyser.FileContext exposing (FileContext)
 import Analyser.FileRef exposing (FileRef)
 import Analyser.Fixers
 import Analyser.Fixes.Base exposing (Fixer, Patch(..))
@@ -70,24 +69,6 @@ initWithMessage mess state =
                 , State.startFixing mess state
                 )
             )
-
-
-getFixedFile : Message -> FileContext -> Result String String
-getFixedFile mess fileContext =
-    Analyser.Fixers.getFixer mess
-        |> Maybe.map
-            (\fixer ->
-                case fixer.fix ( fileContext.content, fileContext.ast ) mess.data of
-                    Error e ->
-                        Err e
-
-                    Patched p ->
-                        Ok p
-
-                    IncompatibleData ->
-                        Err ("Invalid message data for fixer, message id: " ++ String.fromInt mess.id)
-            )
-        |> Maybe.withDefault (Err "Unable to find fixer")
 
 
 isDone : Model -> Bool

--- a/src/Analyser/Fixers.elm
+++ b/src/Analyser/Fixers.elm
@@ -1,4 +1,4 @@
-module Analyser.Fixers exposing (all, getFixer)
+module Analyser.Fixers exposing (all, canFix, getFixer)
 
 import Analyser.Fixes.Base exposing (Fixer)
 import Analyser.Fixes.DropConsOfItemAndList as DropConsOfItemAndList
@@ -17,6 +17,11 @@ getFixer : Message -> Maybe Fixer
 getFixer m =
     List.filter (\x -> x.canFix == m.type_) all
         |> List.head
+
+
+canFix : Message -> Bool
+canFix m =
+    getFixer m /= Nothing
 
 
 all : List Fixer

--- a/src/Analyser/QuickFixer.elm
+++ b/src/Analyser/QuickFixer.elm
@@ -1,0 +1,91 @@
+module Analyser.QuickFixer exposing (fix, fixAll)
+
+import Analyser.CodeBase as CodeBase exposing (CodeBase)
+import Analyser.Configuration exposing (Configuration)
+import Analyser.FileContext as FileContext exposing (FileContext)
+import Analyser.Files.FileLoader as FileLoader
+import Analyser.Fixers as Fixers
+import Analyser.Fixes.Base exposing (Patch(..))
+import Analyser.Messages.Types exposing (Message)
+import Inspection
+import Maybe.Extra as Maybe
+
+
+fix : CodeBase -> Message -> Result String FileContext
+fix codeBase message =
+    let
+        messageId =
+            String.fromInt message.id
+    in
+    case getFileContext message.file.path codeBase of
+        Just fileContext ->
+            Fixers.getFixer message
+                |> Maybe.map
+                    (\fixer ->
+                        case fixer.fix ( fileContext.content, fileContext.ast ) message.data of
+                            Error e ->
+                                Err e
+
+                            Patched p ->
+                                Ok { fileContext | content = p }
+
+                            IncompatibleData ->
+                                Err ("Invalid message data for fixer, message id: " ++ messageId)
+                    )
+                |> Maybe.withDefault (Err ("Unable to find fixer for messageId: " ++ messageId))
+
+        Nothing ->
+            Err ("Unable to find file for message id: " ++ messageId)
+
+
+fixAll : Configuration -> CodeBase -> List Message -> String -> Result String String
+fixAll configuration codeBase messages path =
+    case getFileContext path codeBase of
+        Just fileContext ->
+            Ok (fixAllHelp configuration codeBase messages fileContext).content
+
+        Nothing ->
+            Err ("Unable to find file in code base, path: " ++ path)
+
+
+{-| Recursively fix a file, re-inspecting after each fix
+-}
+fixAllHelp : Configuration -> CodeBase -> List Message -> FileContext -> FileContext
+fixAllHelp configuration codeBase messages fileContext =
+    case messages of
+        [] ->
+            fileContext
+
+        message :: _ ->
+            let
+                nextFileContext =
+                    fix codeBase message
+                        |> Result.withDefault fileContext
+
+                loadedSourceFile =
+                    Tuple.first <|
+                        FileLoader.load
+                            { path = nextFileContext.file.path
+                            , success = True
+                            , sha1 = Nothing
+                            , content = Just nextFileContext.content
+                            , ast = Nothing
+                            }
+
+                nextCodeBase =
+                    CodeBase.addSourceFiles [ loadedSourceFile ] codeBase
+            in
+            fixAllHelp
+                configuration
+                nextCodeBase
+                (Inspection.run nextCodeBase [ loadedSourceFile ] configuration
+                    |> List.filter Fixers.canFix
+                )
+                nextFileContext
+
+
+getFileContext : String -> CodeBase -> Maybe FileContext
+getFileContext path codeBase =
+    CodeBase.getFile path codeBase
+        |> Maybe.map (FileContext.buildForFile (CodeBase.processContext codeBase))
+        |> Maybe.join

--- a/src/Analyser/State.elm
+++ b/src/Analyser/State.elm
@@ -7,6 +7,7 @@ module Analyser.State exposing
     , encodeStatus
     , finishWithNewMessages
     , getMessage
+    , getMessagesForFile
     , initialState
     , isBusy
     , nextTask
@@ -75,6 +76,11 @@ isBusy s =
 getMessage : MessageId -> State -> Maybe Message
 getMessage messageId =
     .messages >> List.filter (.id >> (==) messageId) >> List.head
+
+
+getMessagesForFile : String -> State -> List Message
+getMessagesForFile path =
+    .messages >> List.filter (\m -> m.file.path == path)
 
 
 nextTask : State -> Maybe ( State, MessageId )

--- a/src/AnalyserPorts.elm
+++ b/src/AnalyserPorts.elm
@@ -1,4 +1,4 @@
-port module AnalyserPorts exposing (onFixMessage, onFixQuick, onReset, sendFixedFile, sendReport, sendStateValue)
+port module AnalyserPorts exposing (onFixFileMessage, onFixFileQuick, onFixMessage, onFixQuick, onReset, sendFixedFile, sendReport, sendStateValue)
 
 import Analyser.Report as Report exposing (Report)
 import Analyser.State exposing (State, encodeState)
@@ -20,7 +20,13 @@ port onReset : (Bool -> msg) -> Sub msg
 port onFixMessage : (Int -> msg) -> Sub msg
 
 
+port onFixFileMessage : (String -> msg) -> Sub msg
+
+
 port onFixQuick : (Int -> msg) -> Sub msg
+
+
+port onFixFileQuick : (String -> msg) -> Sub msg
 
 
 sendReport : Report -> Cmd msg

--- a/ts/analyser.ts
+++ b/ts/analyser.ts
@@ -2,8 +2,9 @@ import * as fileLoadingPorts from './file-loading-ports';
 import * as loggingPorts from './util/logging-ports';
 import { Registry } from './util/dependencies';
 import * as dependencies from './util/dependencies';
-import { ElmApp, Config, Report } from './domain';
+import { ElmApp, Config, Report, FileStore } from './domain';
 import Reporter from './reporter';
+import { printInPlace } from './util/logging-ports';
 
 const directory = process.cwd();
 const Elm = require('./backend-elm');
@@ -11,6 +12,69 @@ const Elm = require('./backend-elm');
 function start(config: Config, project: {}) {
     const reporter = Reporter.build(config.format);
 
+    startAnalyser(config, project, function(_, report: Report) {
+        reporter.report(report);
+        const fail = report.messages.length > 0 || report.unusedDependencies.length > 0;
+        process.exit(fail ? 1 : 0);
+    });
+}
+
+function fix(path: string, config: Config, project: {}) {
+    let initialReport: Report;
+    startAnalyser(config, project, function onReport(app: ElmApp, report: Report) {
+        if (!initialReport) {
+            initialReport = report;
+        } else {
+            let reportForFile = { ...initialReport, messages: initialReport.messages.filter(m => m.file == path) };
+            let newReportForFile = { ...report, messages: report.messages.filter(m => m.file == path) };
+            printReport(`Fix Complete for ${path}`, reportForFile, newReportForFile);
+            return;
+        }
+        app.ports.storeFile.subscribe(() => {
+            printInPlace(`Writing file: ${path}`);
+            app.ports.onReset.send(true);
+        });
+        app.ports.onFixFileMessage.send(path);
+    });
+}
+
+function fixAll(config: Config, project: {}) {
+    let initialReport: Report;
+    startAnalyser(config, project, function onReport(app: ElmApp, report: Report) {
+        if (!initialReport) {
+            initialReport = report;
+        } else {
+            printReport(`Fix Complete`, initialReport, report);
+            return;
+        }
+
+        const files = new Set(report.messages.map(m => m.file));
+        let filesLeftToSave = files.size;
+        app.ports.storeFile.subscribe((fileStore: FileStore) => {
+            printInPlace(`Writing file ${fileStore.file}`);
+            filesLeftToSave--;
+            if (filesLeftToSave === 0) {
+                app.ports.onReset.send(true);
+            }
+        });
+        files.forEach((file: string) => {
+            printInPlace(`Fixing file: ${file}`);
+            app.ports.onFixFileMessage.send(file);
+        });
+    });
+}
+
+function printReport(title: string, initialReport: Report, newReport: Report) {
+    console.log('\n');
+    console.log(`Elm Analyse - ${title}`);
+    console.log('------------------------------');
+    console.log(`Messages Before: ${initialReport.messages.length}`);
+    console.log(`Messages After : ${newReport.messages.length}`);
+    console.log(`Issues Fixed   : ${initialReport.messages.length - newReport.messages.length}`);
+    console.log('------------------------------');
+}
+
+function startAnalyser(config: Config, project = {}, onReport: (app: ElmApp, report: Report) => any) {
     dependencies.getDependencies(function(registry: Registry) {
         const app: ElmApp = Elm.Elm.Analyser.init({
             flags: {
@@ -20,10 +84,8 @@ function start(config: Config, project: {}) {
             }
         });
 
-        app.ports.sendReportValue.subscribe(function(report: Report) {
-            reporter.report(report);
-            const fail = report.messages.length > 0 || report.unusedDependencies.length > 0;
-            process.exit(fail ? 1 : 0);
+        app.ports.sendReportValue.subscribe(function(report) {
+            onReport(app, report);
         });
 
         loggingPorts.setup(app, config);
@@ -31,4 +93,4 @@ function start(config: Config, project: {}) {
     });
 }
 
-export default { start };
+export default { start, fix, fixAll };

--- a/ts/bin/index.ts
+++ b/ts/bin/index.ts
@@ -12,10 +12,11 @@ var args = minimist(process.argv.slice(2), {
         help: 'h',
         port: 'p',
         version: 'v',
-        open: 'o'
+        open: 'o',
+        fix: 'f'
     },
-    boolean: ['serve', 'help', 'version', 'open'],
-    string: ['port', 'elm-format-path', 'format']
+    boolean: ['serve', 'help', 'version', 'open', 'fix-all'],
+    string: ['port', 'elm-format-path', 'format', 'fix']
 });
 
 (function() {
@@ -45,6 +46,10 @@ var args = minimist(process.argv.slice(2), {
         console.log(
             '    # Analyse the project and start a server. Allows inspection of messages through a browser (Default: http://localhost:3000).\n'
         );
+        console.log('  $ elm-analyse --fix src/Main.elm');
+        console.log('    # Fix a single file and write it back to disk.\n');
+        console.log('  $ elm-analyse --fix-all');
+        console.log('    # Fix all files in a project and write them to disk.\n');
         console.log('Options: ');
         console.log('   --help, -h          Print the help output.');
         console.log('   --serve, -s         Enable server mode. Disabled by default.');
@@ -52,6 +57,8 @@ var args = minimist(process.argv.slice(2), {
         console.log('   --open, -o          Open default browser when server goes live.');
         console.log('   --elm-format-path   Path to elm-format. Defaults to `elm-format`.');
         console.log('   --format            Output format for CLI. Defaults to "human". Options "human"|"json"');
+        console.log('   --fix, -f           Fix a file');
+        console.log('   --fix-all           Fix a whole project');
         process.exit(1);
     }
 
@@ -71,6 +78,12 @@ var args = minimist(process.argv.slice(2), {
     if (args.serve) {
         Server.start(config, info, projectFile);
         return;
+    }
+    if (args.fix) {
+        return Analyser.fix(args.fix, config, projectFile);
+    }
+    if (args['fix-all']) {
+        return Analyser.fixAll(config, projectFile);
     }
     Analyser.start(config, projectFile);
 })();

--- a/ts/domain.ts
+++ b/ts/domain.ts
@@ -70,7 +70,9 @@ interface ElmApp {
         fileWatch: MailBox<FileChange>;
         onReset: MailBox<boolean>;
         onFixMessage: MailBox<number>;
+        onFixFileMessage: MailBox<string>;
         onFixQuick: MailBox<number>;
+        onFixFileQuick: MailBox<string>;
         onLoadedContext: MailBox<Context>;
         onDependencyFiles: MailBox<DependencyFiles>;
         fileContent: MailBox<FileContent>;

--- a/ts/ports/file-loader.ts
+++ b/ts/ports/file-loader.ts
@@ -3,6 +3,7 @@ import { LocalCache } from '../util/cache';
 import * as cp from 'child_process';
 import { ElmApp, FileStore, AstStore, Config, FileContent, FileContentSha } from '../domain';
 import { FileReader } from '../fileReader';
+import { printInPlace } from '../util/logging-ports';
 
 function setup(app: ElmApp, config: Config, directory: string, cache: LocalCache, fileReader: FileReader) {
     app.ports.loadFile.subscribe(fileName => {
@@ -22,10 +23,10 @@ function setup(app: ElmApp, config: Config, directory: string, cache: LocalCache
                     cp.execSync(config.elmFormatPath + ' --yes ' + file.file, {
                         stdio: []
                     });
-                    console.log('Formatted file', file.file);
+                    printInPlace(`Formatted file: ${file.file}`);
                     accept();
                 } catch (e) {
-                    console.log('Could not formated file', file.file);
+                    console.log('Could not format file', file.file);
                     accept();
                 }
             });

--- a/ts/util/logging-ports.ts
+++ b/ts/util/logging-ports.ts
@@ -1,9 +1,20 @@
 import { Config, ElmApp, LogMessage } from '../domain';
+import * as readline from 'readline';
 
 export function setup(app: ElmApp, config: Config) {
     if (config.format === 'human') {
         app.ports.log.subscribe((data: LogMessage) => {
-            console.log(data.level + ':', data.message);
+            if (data.level === 'INFO') {
+                printInPlace(data.level + ':' + data.message);
+            } else {
+                console.log(data.level, data.message);
+            }
         });
     }
+}
+
+export function printInPlace(str: string) {
+    readline.clearLine(process.stdout, 0);
+    readline.cursorTo(process.stdout, 0);
+    process.stdout.write(str);
 }


### PR DESCRIPTION
This came about from integration with the language server so that we could have a "Fix all issues in this file" action, it seemed like it would be nice to have in the CLI tool, so I also added some options for that.

- To fix a single file: `elm-analyse --fix src/Main.elm` or `elm-analyse -f src/Main.elm`

![fix-file](https://user-images.githubusercontent.com/1693421/59813714-957f7a80-92e0-11e9-922b-fee63b53b578.gif)

- To fix an entire project: `elm-analyse --fix-all`

![fix-all](https://user-images.githubusercontent.com/1693421/59813835-09ba1e00-92e1-11e9-8549-aa757435d4a7.gif)

- Less verbose logging when running in CLI mode, it now replaces the output of each line for info messages, and prints other messages on newlines.  I'm not sure if belongs along with this PR, if you aren't a fan I can remove it :)

When fixing a file it will apply a single fix, then re-analyze the file, and apply the next fix. I tried fixing files from the bottom up, but ran into issues when there were multiple issues on one line, like in an import list with a few unused variables.
