### PR TITLE
Find more uses of imports in patterns

### DIFF
--- a/tests/Analyser/Checks/UnusedImportTests.elm
+++ b/tests/Analyser/Checks/UnusedImportTests.elm
@@ -37,6 +37,44 @@ z a =
     )
 
 
+usedInFunctionArgs : ( String, String, List MessageData )
+usedInFunctionArgs =
+    ( "usedInFunctionArgs", """
+module Main exposing (..)
+
+import Bar
+
+x (Bar.Bar _) =
+    0
+""", [] )
+
+
+usedInLambdaArgs : ( String, String, List MessageData )
+usedInLambdaArgs =
+    ( "usedInLambda", """
+module Main exposing (..)
+
+import Bar
+
+x = \\(Bar.Bar _) -> 0
+""", [] )
+
+
+usedInLetPattern : ( String, String, List MessageData )
+usedInLetPattern =
+    ( "usedInLetPattern", """
+module Main exposing (..)
+
+import Bar
+
+x a =
+    let
+        (Bar.Bar _) = a
+    in
+        0
+""", [] )
+
+
 usedInTypeReference : ( String, String, List MessageData )
 usedInTypeReference =
     ( "usedInTypeReference"
@@ -119,6 +157,9 @@ all =
         UnusedImport.checker
         [ usedAsQualified
         , usedAsQualifiedInPattern
+        , usedInFunctionArgs
+        , usedInLambdaArgs
+        , usedInLetPattern
         , usedInTypeReference
         , usedInTypeAlias
         , unusedButHasAlias


### PR DESCRIPTION
I had some code, something like the sample below, that was incorrectly triggering the "unused import" warning:

```elm
-- A.elm
module A exposing (A(..))

type A =
    A Int

-- B.elm
module B

import A

x =
    \(A.A _) -> 0
```

This PR fixes that case and several other ones where imported modules are only used in patterns. I tested by updating my code for each case and testing that the warning disappeared when I added the checking code to handle that case (and by adding new tests that failed with the old code but pass with the new code).