### PR TITLE
Security: Bump minimist to 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "find": "0.2.7",
     "fs-extra": "2.0.0",
     "lodash": "^4.17.15",
-    "minimist": "1.2.0",
+    "minimist": "^1.2.2",
     "node-watch": "0.5.5",
     "opn": "5.4.0",
     "os-homedir": "1.0.2",


### PR DESCRIPTION
This adresses a moderate severity prototype pollution attack in minimist <1.2.2 https://app.snyk.io/vuln/SNYK-JS-MINIMIST-559764