### PR TITLE
Upgrade minimist to address security vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "find": "0.2.7",
     "fs-extra": "2.0.0",
     "lodash": "^4.17.15",
-    "minimist": "^1.2.5",
+    "minimist": "^1.2.6",
     "node-watch": "0.5.5",
     "opn": "6.0.0",
     "os-homedir": "1.0.2",


### PR DESCRIPTION
https://github.com/substack/minimist#security. 

> Previous versions had a prototype pollution bug that could cause privilege escalation in some circumstances when handling untrusted user input.
>
> Please use version 1.2.6 or later:
>
> https://security.snyk.io/vuln/SNYK-JS-MINIMIST-2429795 (version <=1.2.5)
> https://snyk.io/vuln/SNYK-JS-MINIMIST-559764 (version <=1.2.3)